### PR TITLE
Dc iss 150 auto classify service

### DIFF
--- a/infrastructure/backend.yml
+++ b/infrastructure/backend.yml
@@ -40,6 +40,9 @@ Parameters:
     Default: an-db
   ExecutionRole:
     Type: String
+  CertificateArn:
+    Type: String
+    Description: ARN of the ACM certificate for the backend domain (api.dashboard.ga4gh.org)
 
 Resources:
 
@@ -87,6 +90,25 @@ Resources:
       Port:
         Ref: HostPort
       Protocol: HTTP
+
+  ALBHttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn: [
+      ALBBalancer,
+      ALBTargetGroup
+    ]
+    Properties:
+      DefaultActions:
+        - TargetGroupArn:
+            Ref: ALBTargetGroup
+          Type: forward
+      LoadBalancerArn:
+        Ref: ALBBalancer
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
 
   ECSService:
     Type: AWS::ECS::Service

--- a/infrastructure/base_infra.yml
+++ b/infrastructure/base_infra.yml
@@ -63,6 +63,10 @@ Resources:
           ToPort: 5432
           SourcePrefixListId: pl-075eab34a5b428114
         - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
           FromPort: 3000
           ToPort: 3000
           CidrIp: 0.0.0.0/0

--- a/infrastructure/deploy.txt
+++ b/infrastructure/deploy.txt
@@ -3,21 +3,23 @@ Staging
 Step 1:
 Base Infra: One time run to initialize DB instance, DB Password, Log groups, ECS Cluster
 To rerun: Delete existing template and execute
-aws cloudformation deploy \               
-  --template-file base_infra.yml \               
-  --stack-name analytics-dashboard-staging-base \
+aws cloudformation deploy \
+  --template-file base_infra.yml \
+  --stack-name analytics-dashboard \
   --region us-east-2 \
+  --capabilities CAPABILITY_NAMED_IAM \
   --parameter-overrides \
+    StaticStackName=analytics-dashboard \
     Environment=staging \
-    ParamDBName=analytics_dashboard_staging_db \
-    ParamUsername=analytics_dashboard_staging_user \
-    PubliclyAccessible=true \
-    BackupRetentionPeriod=30 \
     VpcId=vpc-01c8c42ad7cf34b4b \
     VpcCidr=10.0.0.0/16 \
     SubnetA=subnet-0f26c31e6c9578717 \
     SubnetB=subnet-00663ce89eb47404f \
-    SubnetC=subnet-08b697026fc4502e5
+    SubnetC=subnet-08b697026fc4502e5 \
+    ParamDBName=analytics_dashboard_staging_db \
+    ParamUsername=analytics_dashboard_staging_user \
+    PubliclyAccessible=true \
+    BackupRetentionPeriod=7
 
 Step 2:
 Migrations
@@ -96,22 +98,40 @@ Deploy backend
 
 cd /Users/dashrath/Documents/GA4GH/Analytics/analytics-dashboard/infrastructure
 
+# Get the correct password
+DBPASS=$(aws secretsmanager get-secret-value \
+  --secret-id analytics-dashboard-staging-DBPassword \
+  --version-stage AWSCURRENT \
+  --region us-east-2 \
+  --query 'SecretString' --output text)
+
+# Get the rest of the stack params (VPC, subnets, etc.)
+aws cloudformation describe-stacks \
+  --stack-name analytics-dashboard-staging-backend \
+  --region us-east-2 \
+  --query 'Stacks[0].Parameters' --output json
+
 aws cloudformation deploy \
-  --template-file backend.yml \
+  --template-file infrastructure/backend.yml \
   --stack-name analytics-dashboard-staging-backend \
   --region us-east-2 \
   --capabilities CAPABILITY_NAMED_IAM \
   --parameter-overrides \
     StaticStackName=analytics-dashboard \
     Environment=staging \
-    ApiImage=282236276875.dkr.ecr.us-east-2.amazonaws.com/analytics-dashboard-api:latest \
     VpcId=vpc-01c8c42ad7cf34b4b \
     SubnetA=subnet-0f26c31e6c9578717 \
     SubnetB=subnet-00663ce89eb47404f \
     SubnetC=subnet-08b697026fc4502e5 \
-    ExecutionRole=arn:aws:iam::282236276875:role/ECSFargateExecutionRole-TT \
+    HostPort=8000 \
+    ParamContainerPort=8000 \
+    ShortName=an-db \
+    Prefix=ecs \
     Region=us-east-2 \
-    DBURL="postgresql://analytics_dashboard_staging_user:pwd@analytics-dashboard-staging-base-database-verhcap8spla.c0q4keadjybw.us-east-2.rds.amazonaws.com:5432/analytics_dashboard_staging_db?sslmode=require"
+    ExecutionRole=arn:aws:iam::282236276875:role/ECSFargateExecutionRole-TT \
+    ApiImage=282236276875.dkr.ecr.us-east-2.amazonaws.com/analytics-dashboard-api:latest \
+    DBURL="postgresql://analytics_dashboard_staging_user:${DBPASS}@analytics-dashboard-staging-base-database-verhcap8spla.c0q4keadjybw.us-east-2.rds.amazonaws.com:5432/analytics_dashboard_staging_db?sslmode=require" \
+    CertificateArn=arn:aws:acm:us-east-2:282236276875:certificate/72a8fde8-ce94-4da7-ba72-57aa225aa695
 
 Step 4:
 Deploy Frontend
@@ -126,7 +146,7 @@ aws cloudformation deploy \
     StaticStackName=analytics-dashboard \
     Environment=staging \
     FrontEndImage=282236276875.dkr.ecr.us-east-2.amazonaws.com/analytics-dashboard-ui:latest \
-    ApiBaseUrl=http://an-db-staging-backend-alb-301627353.us-east-2.elb.amazonaws.com:8000 \
+    ApiBaseUrl=https://api.dashboard.ga4gh.org \     
     VpcId=vpc-01c8c42ad7cf34b4b \
     SubnetA=subnet-0f26c31e6c9578717 \
     SubnetB=subnet-00663ce89eb47404f \
@@ -134,7 +154,7 @@ aws cloudformation deploy \
     ExecutionRole=arn:aws:iam::282236276875:role/ECSFargateExecutionRole-TT \
     Region=us-east-2 \
     ClusterName=analytics-dashboard-staging-ui-cluster \
-    CertificateArn=arn:aws:acm:us-east-2:282236276875:certificate/ae6d656e-a776-4391-932c-24b3aa4d0c4c
+    CertificateArn=arn:aws:acm:us-east-2:282236276875:certificate/72a8fde8-ce94-4da7-ba72-57aa225aa695
 
 
 Update service:

--- a/liquibase/dbchangelog.xml
+++ b/liquibase/dbchangelog.xml
@@ -1137,4 +1137,11 @@
     <changeSet author="dashrath" id="dc-20260820-005">
         <renameColumn tableName="pmc_review" oldColumnName="reviewd_at" newColumnName="reviewed_at" columnDataType="timestamp with time zone"/>
     </changeSet>
+    <changeSet author="dashrath" id="dc-20260820-006">
+        <addColumn tableName="ingestion">
+            <column name="unresolvable_count" type="integer" defaultValueNumeric="0">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/liquibase/dbchangelog.xml
+++ b/liquibase/dbchangelog.xml
@@ -1144,4 +1144,8 @@
             </column>
         </addColumn>
     </changeSet>
+
+    <changeSet author="dashrath" id="dc-20260827-001">
+        <addAutoIncrement tableName="pmc_review" columnName="id" columnDataType="INTEGER"/>
+    </changeSet>
 </databaseChangeLog>

--- a/src/clients/epmc.py
+++ b/src/clients/epmc.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote
 
 logger = logging.getLogger(__name__)
 
@@ -329,12 +330,13 @@ class EPMCClient:
         json_response = self.get_json(self.grants_url, self.get_grants_endpoint(keyword))
         return json_response
 
-    def get_articles_endpoint(self, keyword):
-        return f"search?query={keyword}&format=json&resultType=core"
+    def get_articles_endpoint(self, keyword: str) -> str:
+        return f"search?query={quote(keyword)}&format=json&resultType=core"
 
     def get_delta_articles_endpoint(self, keyword: str, from_date: str, to_date: str) -> str:
         """Build the UPDATE_DATE-filtered search URL for delta pulls."""
-        return f"search?query={keyword}%20UPDATE_DATE%3A%5B{from_date}%20TO%20{to_date}%5D&format=json&resultType=core"
+        full_query = f"({keyword}) AND UPDATE_DATE:[{from_date} TO {to_date}]"
+        return f"search?query={quote(full_query)}&format=json&resultType=core"
 
     def get_citations_endpoint(self, id, source="MED"):
         return f"{source}/{id}/citations?format=json"
@@ -374,6 +376,9 @@ class EPMCClient:
             if iters >= max_iters:
                 break
             iters += 1
+
+            if iters == 1:
+                logger.info("EPMC request: GET %s params=%s", url, params)
 
             resp = requests.get(url, headers=headers, params=params, timeout=30)
             resp.raise_for_status()

--- a/src/clients/epmc.py
+++ b/src/clients/epmc.py
@@ -309,14 +309,16 @@ class EPMCClient:
             rows_count=rows_count,
         )
 
-    def get_articles(self, keyword):
-        json_response = self.get_json(self.base_url, self.get_articles_endpoint(keyword))
-        return json_response
+    def get_articles(self, keyword: str) -> Dict[str, Any]:
+        endpoint = self.get_articles_endpoint(keyword)
+        logger.info("EPMC full pull: %s%s", self.base_url, endpoint)
+        return self.get_json(self.base_url, endpoint, per_page=1000)
 
     def get_delta_articles(self, keyword: str, from_date: str, to_date: str) -> Dict[str, Any]:
         """Fetch only articles updated between from_date and to_date (YYYY-MM-DD)."""
-        json_response = self.get_json(self.base_url, self.get_delta_articles_endpoint(keyword, from_date, to_date))
-        return json_response
+        endpoint = self.get_delta_articles_endpoint(keyword, from_date, to_date)
+        logger.info("EPMC delta pull: %s%s", self.base_url, endpoint)
+        return self.get_json(self.base_url, endpoint, per_page=1000)
 
     def get_references(self, id, source="MED"):
         json_response = self.get_json(self.base_url, self.get_references_endpoint(id, source=source))
@@ -378,7 +380,7 @@ class EPMCClient:
             iters += 1
 
             if iters == 1:
-                logger.info("EPMC request: GET %s params=%s", url, params)
+                logger.debug("EPMC request: GET %s params=%s", url, params)
 
             resp = requests.get(url, headers=headers, params=params, timeout=30)
             resp.raise_for_status()

--- a/src/clients/epmc.py
+++ b/src/clients/epmc.py
@@ -28,10 +28,11 @@ class EPMCClient:
 
     def create_article(self, article_data, record_id, ingestion_id: int, created_by: str = "system", cited_by: int = 0) -> PMCArticle:
         return PMCArticle(
-            id=None,  
+            id=None,
             record_id=record_id,
             ingestion_id=ingestion_id,
             source=article_data.get("source", ""),
+            epmc_id=article_data.get("id"),
             pm_id=article_data.get("id"),
             pmc_id=article_data.get("pmcid", "") or "",
             full_text_id=((article_data.get("fullTextIdList") or {}).get("fullTextId") or ""),
@@ -282,23 +283,38 @@ class EPMCClient:
         )
     
 
-    def create_ingestion(self, version, created_by: str = "system") -> Ingestion:
+    def create_ingestion(
+        self,
+        version,
+        keyword: Optional[str] = None,
+        run_type: str = "full",
+        api_version: Optional[str] = None,
+        created_by: str = "system",
+    ) -> Ingestion:
         return Ingestion(
             id=None,
-            ingested_at=datetime.utcnow(), 
+            ingested_at=datetime.utcnow(),
+            keyword=keyword,
+            run_type=run_type,
+            api_version=api_version,
             created_by=created_by,
             created_at=datetime.utcnow(),
-            version=version
+            version=version,
         )
-    
+
     def update_ingestion(self, ingestion_id, rows_count: int) -> Ingestion:
         return Ingestion(
             id=ingestion_id,
-            rows_count=rows_count
+            rows_count=rows_count,
         )
 
     def get_articles(self, keyword):
-        json_response = self.get_json(self.base_url, self.get_articles_endpoint(keyword))        
+        json_response = self.get_json(self.base_url, self.get_articles_endpoint(keyword))
+        return json_response
+
+    def get_delta_articles(self, keyword: str, from_date: str, to_date: str) -> Dict[str, Any]:
+        """Fetch only articles updated between from_date and to_date (YYYY-MM-DD)."""
+        json_response = self.get_json(self.base_url, self.get_delta_articles_endpoint(keyword, from_date, to_date))
         return json_response
 
     def get_references(self, id, source="MED"):
@@ -315,6 +331,10 @@ class EPMCClient:
 
     def get_articles_endpoint(self, keyword):
         return f"search?query={keyword}&format=json&resultType=core"
+
+    def get_delta_articles_endpoint(self, keyword: str, from_date: str, to_date: str) -> str:
+        """Build the UPDATE_DATE-filtered search URL for delta pulls."""
+        return f"search?query={keyword}%20UPDATE_DATE%3A%5B{from_date}%20TO%20{to_date}%5D&format=json&resultType=core"
 
     def get_citations_endpoint(self, id, source="MED"):
         return f"{source}/{id}/citations?format=json"

--- a/src/models/entities/audit_log.py
+++ b/src/models/entities/audit_log.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from sqlalchemy import ForeignKey, Integer, String, Text, TIMESTAMP
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_log"
+
+    # ---------- PK ----------
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # ---------- Event ----------
+    event_type: Mapped[str] = mapped_column(String, nullable=False)
+    environment: Mapped[Optional[str]] = mapped_column(String)
+    entity_type: Mapped[Optional[str]] = mapped_column(String)
+    entity_id: Mapped[Optional[str]] = mapped_column(String)
+
+    # ---------- Identity ----------
+    epmc_id: Mapped[Optional[str]] = mapped_column(String)
+    doi: Mapped[Optional[str]] = mapped_column(String)
+
+    # ---------- FK ----------
+    ingestion_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("ingestion.id", ondelete="NO ACTION")
+    )
+    review_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("pmc_review.id", ondelete="NO ACTION")
+    )
+
+    # ---------- Values ----------
+    old_value: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB)
+    new_value: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB)
+    comment: Mapped[Optional[str]] = mapped_column(Text)
+
+    # ---------- Actor ----------
+    action_by: Mapped[Optional[str]] = mapped_column(String)
+    action_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))

--- a/src/models/entities/enums.py
+++ b/src/models/entities/enums.py
@@ -1,0 +1,70 @@
+from enum import Enum
+
+
+class AuditEventType(str, Enum):
+    """
+    Canonical event types written to the audit_log table.
+    Covers the full lifecycle of a record through the curation pipeline.
+
+    INGESTION
+      INGESTION_STARTED                 — ingestion run begins (full or delta pull)
+      INGESTION_COMPLETED               — all articles written to staging, counts updated
+      INGESTION_FAILED                  — pipeline raised an unhandled exception
+
+    CLASSIFICATION  (one per article per run)
+      ARTICLE_CLASSIFIED_NEW            — no match in production (new record)
+      ARTICLE_CLASSIFIED_UNCHANGED      — matched, diff is empty
+      ARTICLE_CLASSIFIED_CHANGED        — matched, effective diff is non-empty
+      ARTICLE_CLASSIFIED_KNOWN_DIV      — matched, all diff fields suppressed by known_divergences
+      ARTICLE_UNRESOLVABLE              — no epmc_id or doi to match on
+      INGESTION_CLASSIFICATION_COMPLETE — end of classify_ingestion_run(), carries count summary
+
+    REVIEW  (human curator actions on pmc_review rows)
+      REVIEW_APPROVED                   — curator accepted the incoming EPMC value
+      REVIEW_REJECTED                   — curator kept the existing production value
+      REVIEW_DEFERRED                   — curator postponed the decision
+
+    KNOWN DIVERGENCE  (curator managing known_divergences table)
+      KNOWN_DIVERGENCE_CREATED          — curator marked a field difference as a known divergence
+      KNOWN_DIVERGENCE_DEACTIVATED      — known divergence retired (EPMC value now accepted)
+
+    PROMOTION  (record lifecycle between staging and production)
+      ARTICLE_PROMOTED                  — new article approved and written to production DB
+      ARTICLE_PROMOTION_FAILED          — promotion attempt raised an error
+      PRODUCTION_ARTICLE_UPDATED        — existing production record updated after approved CHANGED review
+      PRODUCTION_UPDATE_FAILED          — production update attempt raised an error
+
+    BASELINE
+      BASELINE_MIGRATION_COMPLETE       — one-time backfill: existing records set approved_by='system'
+    """
+
+    # ---------- Ingestion lifecycle ----------
+    INGESTION_STARTED = "INGESTION_STARTED"
+    INGESTION_COMPLETED = "INGESTION_COMPLETED"
+    INGESTION_FAILED = "INGESTION_FAILED"
+
+    # ---------- Classification ----------
+    ARTICLE_CLASSIFIED_NEW = "ARTICLE_CLASSIFIED_NEW"
+    ARTICLE_CLASSIFIED_UNCHANGED = "ARTICLE_CLASSIFIED_UNCHANGED"
+    ARTICLE_CLASSIFIED_CHANGED = "ARTICLE_CLASSIFIED_CHANGED"
+    ARTICLE_CLASSIFIED_KNOWN_DIV = "ARTICLE_CLASSIFIED_KNOWN_DIV"
+    ARTICLE_UNRESOLVABLE = "ARTICLE_UNRESOLVABLE"
+    INGESTION_CLASSIFICATION_COMPLETE = "INGESTION_CLASSIFICATION_COMPLETE"
+
+    # ---------- Human review actions ----------
+    REVIEW_APPROVED = "REVIEW_APPROVED"
+    REVIEW_REJECTED = "REVIEW_REJECTED"
+    REVIEW_DEFERRED = "REVIEW_DEFERRED"
+
+    # ---------- Known divergence management ----------
+    KNOWN_DIVERGENCE_CREATED = "KNOWN_DIVERGENCE_CREATED"
+    KNOWN_DIVERGENCE_DEACTIVATED = "KNOWN_DIVERGENCE_DEACTIVATED"
+
+    # ---------- Promotion ----------
+    ARTICLE_PROMOTED = "ARTICLE_PROMOTED"
+    ARTICLE_PROMOTION_FAILED = "ARTICLE_PROMOTION_FAILED"
+    PRODUCTION_ARTICLE_UPDATED = "PRODUCTION_ARTICLE_UPDATED"
+    PRODUCTION_UPDATE_FAILED = "PRODUCTION_UPDATE_FAILED"
+
+    # ---------- Baseline ----------
+    BASELINE_MIGRATION_COMPLETE = "BASELINE_MIGRATION_COMPLETE"

--- a/src/models/entities/ingestion.py
+++ b/src/models/entities/ingestion.py
@@ -14,17 +14,25 @@ class Ingestion(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
 
     # ---------- Core fields ----------
-    ingested_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True),
-        nullable=False,
-    )
-    rows_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    ingested_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    rows_count: Mapped[Optional[int]] = mapped_column(Integer)
+    keyword: Mapped[Optional[str]] = mapped_column(String)
+    api_version: Mapped[Optional[str]] = mapped_column(String)
+
+    # ---------- Run type ----------
+    run_type: Mapped[Optional[str]] = mapped_column(String(10), default="full")
+
+    # ---------- Classification counts (written at INGESTION_COMPLETED) ----------
+    total_pulled: Mapped[Optional[int]] = mapped_column(Integer)
+    new_count: Mapped[Optional[int]] = mapped_column(Integer)
+    unchanged_count: Mapped[Optional[int]] = mapped_column(Integer)
+    changed_count: Mapped[Optional[int]] = mapped_column(Integer)
+    auto_approved_count: Mapped[Optional[int]] = mapped_column(Integer)
+    pending_review_count: Mapped[Optional[int]] = mapped_column(Integer)
+    unresolvable_count: Mapped[Optional[int]] = mapped_column(Integer)
 
     # ---------- Audit ----------
     created_by: Mapped[str] = mapped_column(String(64), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True),
-        nullable=False,
-    )
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
     version: Mapped[int] = mapped_column(Integer, default=1)
     

--- a/src/models/entities/known_divergence.py
+++ b/src/models/entities/known_divergence.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Boolean, ForeignKey, Integer, String, Text, TIMESTAMP
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class KnownDivergence(Base):
+    __tablename__ = "known_divergences"
+
+    # ---------- PK ----------
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # ---------- FK ----------
+    ingestion_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("ingestion.id", ondelete="CASCADE")
+    )
+    review_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("pmc_review.id", ondelete="CASCADE")
+    )
+
+    # ---------- Identity ----------
+    epmc_id: Mapped[Optional[str]] = mapped_column(String(64))
+    doi: Mapped[Optional[str]] = mapped_column(String(128))
+
+    # ---------- Divergence detail ----------
+    field_path: Mapped[str] = mapped_column(Text, nullable=False)
+    epmc_value: Mapped[Optional[str]] = mapped_column(Text)
+    retained_value: Mapped[Optional[str]] = mapped_column(Text)
+
+    # ---------- State ----------
+    active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    # ---------- Rejection ----------
+    rejected_by: Mapped[Optional[str]] = mapped_column(String(64))
+    rejected_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+    review_comment: Mapped[Optional[str]] = mapped_column(Text)
+
+    # ---------- Audit ----------
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)

--- a/src/models/entities/pmc_article.py
+++ b/src/models/entities/pmc_article.py
@@ -96,6 +96,11 @@ class PMCArticle(Base):
 
     version: Mapped[int] = mapped_column(Integer, default=1)
 
+    # ---------- Curation ----------
+    epmc_id: Mapped[Optional[str]] = mapped_column(String(64))
+    approved_by: Mapped[Optional[str]] = mapped_column(String(64))
+    approved_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+
     # ---------- Relationships ----------
     article_authors: Mapped[List["ArticleAuthor"]] = relationship(
         cascade="all, delete-orphan",

--- a/src/models/entities/pmc_review.py
+++ b/src/models/entities/pmc_review.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from sqlalchemy import Boolean, ForeignKey, Integer, String, Text, TIMESTAMP
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class PMCReview(Base):
+    __tablename__ = "pmc_review"
+
+    # ---------- PK ----------
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # ---------- FK ----------
+    ingestion_id: Mapped[int] = mapped_column(
+        ForeignKey("ingestion.id", ondelete="CASCADE"), nullable=False
+    )
+    staging_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("pmc_articles.id", ondelete="NO ACTION")
+    )
+
+    # ---------- Identity ----------
+    epmc_id: Mapped[Optional[str]] = mapped_column(String(64))
+    doi: Mapped[Optional[str]] = mapped_column(String(128))
+
+    # ---------- Classification ----------
+    review_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    diff: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB)
+
+    # ---------- Auto-approve ----------
+    auto_approved: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    auto_approve_reason: Mapped[Optional[str]] = mapped_column(Text)
+
+    # ---------- Review ----------
+    review_status: Mapped[str] = mapped_column(String(32), default="pending", nullable=False)
+    reviewed_by: Mapped[Optional[str]] = mapped_column(String(64))
+    reviewed_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+    review_comment: Mapped[Optional[str]] = mapped_column(Text)
+
+    # ---------- Audit ----------
+    created_by: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)

--- a/src/models/pmc_article.py
+++ b/src/models/pmc_article.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 
 
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 
 
 class PMCFullText(BaseModel):
@@ -120,6 +120,13 @@ class PMCArticle(BaseModel):
     publication_status: str  
     language: str
     pub_type: Optional[str] = None
+
+    @field_validator("pub_type", mode="before")
+    @classmethod
+    def coerce_pub_type(cls, v):
+        if isinstance(v, list):
+            return v[0] if v else None
+        return v
 
     is_open_access: bool = False
     inepmc: bool = False

--- a/src/repositories/epmc.py
+++ b/src/repositories/epmc.py
@@ -804,6 +804,25 @@ class EPMCRepo:
         self.db.flush()
         return review.id
 
+    def get_pending_review_by_epmc_id(self, epmc_id: str) -> Optional[PMCReview]:
+        """Return the active pending pmc_review row for an article, if one exists."""
+        return (
+            self.db.execute(
+                select(PMCReview)
+                .where(PMCReview.epmc_id == epmc_id)
+                .where(PMCReview.review_status == "pending")
+                .order_by(PMCReview.id.desc())
+                .limit(1)
+            ).scalar_one_or_none()
+        )
+
+    def update_review(self, review_id: int, updates: dict) -> None:
+        """Overwrite fields on an existing pmc_review row (used to refresh stale pending rows)."""
+        self.db.execute(
+            sa_update(PMCReview).where(PMCReview.id == review_id).values(**updates)
+        )
+        self.db.flush()
+
     # ------------------------------------------------------------------
     # Curation — article lookups (used by AutoClassifyService)
     # ------------------------------------------------------------------
@@ -817,14 +836,27 @@ class EPMCRepo:
         )
 
     def get_article_by_epmc_id(self, epmc_id: str) -> Optional[PMCArticle]:
-        return self.db.execute(
-            select(PMCArticle).where(PMCArticle.epmc_id == epmc_id)
-        ).scalar_one_or_none()
+        # Use first() — production DB may have duplicate epmc_id rows from pre-curation
+        # data. Take the row with the highest id (most recently approved version).
+        return (
+            self.db.execute(
+                select(PMCArticle)
+                .where(PMCArticle.epmc_id == epmc_id)
+                .order_by(PMCArticle.id.desc())
+                .limit(1)
+            ).scalar_one_or_none()
+        )
 
     def get_article_by_doi(self, doi: str) -> Optional[PMCArticle]:
-        return self.db.execute(
-            select(PMCArticle).where(PMCArticle.doi == doi)
-        ).scalar_one_or_none()
+        # Same defensive approach for doi lookups.
+        return (
+            self.db.execute(
+                select(PMCArticle)
+                .where(PMCArticle.doi == doi)
+                .order_by(PMCArticle.id.desc())
+                .limit(1)
+            ).scalar_one_or_none()
+        )
 
     def get_active_known_divergences(
         self, epmc_id: Optional[str], doi: Optional[str]

--- a/src/repositories/epmc.py
+++ b/src/repositories/epmc.py
@@ -762,6 +762,10 @@ class EPMCRepo:
         except Exception:
             logger.warning("Could not parse max ingestion version: %r", max_ver)
             return 0
+
+    def get_last_ingestion_date(self) -> Optional[datetime]:
+        """Return the most recent ingested_at timestamp, or None if no runs exist."""
+        return self.db.query(func.max(Ingestion.ingested_at)).scalar()
         
     def get_all_latest_entries(self, pm_id: Optional[str] = None, limit: int = 100, skip: int = 0) -> dict[str, list[Any]]:
         """

--- a/src/repositories/epmc.py
+++ b/src/repositories/epmc.py
@@ -12,7 +12,7 @@ import json
 
 from sqlalchemy.orm import Session, selectinload, raiseload
 from sqlalchemy.exc import OperationalError
-from sqlalchemy import func, and_, or_, select
+from sqlalchemy import func, and_, or_, select, update as sa_update
 from sqlalchemy.sql import literal_column
 from src.config.constants import COUNTRIES, ALIASES
 
@@ -23,6 +23,9 @@ from src.models.entities.citations import Citation, Reference
 from sqlalchemy import func
 from src.models.entities.record import Record
 from src.models.entities.ingestion import Ingestion
+from src.models.entities.audit_log import AuditLog
+from src.models.entities.pmc_review import PMCReview
+from src.models.entities.known_divergence import KnownDivergence
 class EPMCRepo:
     def __init__(self, db: Session):
         
@@ -764,8 +767,77 @@ class EPMCRepo:
             return 0
 
     def get_last_ingestion_date(self) -> Optional[datetime]:
-        """Return the most recent ingested_at timestamp, or None if no runs exist."""
-        return self.db.query(func.max(Ingestion.ingested_at)).scalar()
+        """Return the most recent ingested_at timestamp of a SUCCESSFUL run.
+
+        A run is considered successful when total_pulled is not NULL — that value
+        is written by update_ingestion_counts() only after classification completes.
+        Failed runs leave total_pulled as NULL and are excluded so their committed
+        ingestion row does not corrupt the next delta window.
+        """
+        return (
+            self.db.query(func.max(Ingestion.ingested_at))
+            .filter(Ingestion.total_pulled.isnot(None))
+            .scalar()
+        )
+
+    def update_ingestion_counts(self, ingestion_id: int, counts: dict) -> None:
+        self.db.execute(
+            sa_update(Ingestion).where(Ingestion.id == ingestion_id).values(**counts)
+        )
+        self.db.flush()
+
+    # ------------------------------------------------------------------
+    # Curation — audit log
+    # ------------------------------------------------------------------
+
+    def insert_audit_log(self, audit_log: AuditLog) -> int:
+        self.db.add(audit_log)
+        self.db.flush()
+        return audit_log.id
+
+    # ------------------------------------------------------------------
+    # Curation — review
+    # ------------------------------------------------------------------
+
+    def insert_review(self, review: PMCReview) -> int:
+        self.db.add(review)
+        self.db.flush()
+        return review.id
+
+    # ------------------------------------------------------------------
+    # Curation — article lookups (used by AutoClassifyService)
+    # ------------------------------------------------------------------
+
+    def get_staged_articles(self, ingestion_id: int) -> List[PMCArticle]:
+        """Return all pmc_articles rows written in a given ingestion run."""
+        return (
+            self.db.execute(select(PMCArticle).where(PMCArticle.ingestion_id == ingestion_id))
+            .scalars()
+            .all()
+        )
+
+    def get_article_by_epmc_id(self, epmc_id: str) -> Optional[PMCArticle]:
+        return self.db.execute(
+            select(PMCArticle).where(PMCArticle.epmc_id == epmc_id)
+        ).scalar_one_or_none()
+
+    def get_article_by_doi(self, doi: str) -> Optional[PMCArticle]:
+        return self.db.execute(
+            select(PMCArticle).where(PMCArticle.doi == doi)
+        ).scalar_one_or_none()
+
+    def get_active_known_divergences(
+        self, epmc_id: Optional[str], doi: Optional[str]
+    ) -> List[KnownDivergence]:
+        """Return active known_divergence rows for a given article identity."""
+        if not epmc_id and not doi:
+            return []
+        query = select(KnownDivergence).where(KnownDivergence.active.is_(True))
+        if epmc_id:
+            query = query.where(KnownDivergence.epmc_id == epmc_id)
+        else:
+            query = query.where(KnownDivergence.doi == doi)
+        return self.db.execute(query).scalars().all()
         
     def get_all_latest_entries(self, pm_id: Optional[str] = None, limit: int = 100, skip: int = 0) -> dict[str, list[Any]]:
         """

--- a/src/routers/epmc.py
+++ b/src/routers/epmc.py
@@ -181,25 +181,56 @@ class EPMC:
             production_repo: EPMCRepo = Depends(get_epmc_repo),
         ):
             service = EPMCService(staging_repo)
-            grant_service = Grant(staging_repo)
 
-            run_type = "delta" if from_date else service._detect_run_type()[0]
+            # ── Phase 1: Delta pull (in-memory, no DB writes) ──────────────────
+            # Determine the delta window: explicit from_date > auto-detect from last
+            # ingestion > skip (first ever run).
+            last_date = staging_repo.get_last_ingestion_date()
+            effective_from = from_date or (last_date.strftime("%Y-%m-%d") if last_date else None)
+
+            delta_epmc_ids: Optional[set] = None
+            if effective_from:
+                delta_epmc_ids = service.fetch_delta_epmc_ids(keyword, effective_from, to_date)
+
+            run_type = "full" if delta_epmc_ids is None else "full+delta"
             service.record_ingestion_started(keyword, run_type=run_type)
-            try:
-                logger.info("Ingesting PMC data for keyword: %s run_type=%s", keyword, run_type)
-                service.insert_articles_by_keyword(keyword, created_by="system", from_date=from_date, to_date=to_date)
-                service.insert_references(created_by="system")
-                grant_service.create_grants(keyword)
 
+            try:
+                # ── Phase 2: Full pull (always writes all articles to staging) ──
+                logger.info(
+                    "Ingesting PMC data: keyword=%s run_type=%s delta_ids=%s",
+                    keyword, run_type,
+                    f"{len(delta_epmc_ids)} updated articles" if delta_epmc_ids is not None else "none",
+                )
+                counts = service.insert_articles_by_keyword(keyword, created_by="system", run_type=run_type)
+                logger.info(
+                    "--- PULL COMPLETE | ingestion_id=%s articles=%d authors=%d "
+                    "affiliations=%d fulltexts=%d ---",
+                    service.ingestion_id,
+                    counts.get("articles", 0),
+                    counts.get("authors", 0),
+                    counts.get("affiliations", 0),
+                    counts.get("fulltexts", 0),
+                )
+
+                # ── Classification: uses Phase 1 delta set to drive diff ────────
+                logger.info("--- CLASSIFICATION STARTING | ingestion_id=%s ---", service.ingestion_id)
                 classify_service = AutoClassifyService(staging_repo, production_repo)
                 classify_result = classify_service.classify_ingestion_run(
                     ingestion_id=service.ingestion_id,
+                    delta_epmc_ids=delta_epmc_ids,
                     created_by="system",
                 )
                 service.record_ingestion_completed(service.ingestion_id, keyword, classify_result)
 
+                # Single commit — articles + classification + reviews + audit logs all atomic
+                staging_repo.commit_to_db()
+
             except Exception as e:
-                service.record_ingestion_failed(service.ingestion_id, keyword, str(e))
+                staging_repo.rollback()
+                # ingestion_id was rolled back — pass None so the audit log
+                # does not reference a non-existent ingestion row
+                service.record_ingestion_failed(None, keyword, str(e))
                 raise HTTPException(status_code=500, detail=f"Ingestion failed: {e}")
 
             articles = staging_repo.get_all_articles()

--- a/src/routers/epmc.py
+++ b/src/routers/epmc.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 from fastapi import APIRouter, HTTPException, Depends, Body
 from sqlalchemy.orm import Session
 import json
@@ -10,9 +11,7 @@ from src.services.epmc import EPMCService as EPMCService
 from src.repositories.epmc import EPMCRepo as EPMCRepo
 from src.services.grant import GrantService as Grant
 from src.services.auto_classify import AutoClassifyService
-from src.models.entities.audit_log import AuditLog
-from src.models.entities.enums import AuditEventType
-from src.config.session import get_session, get_staging_db, get_production_db
+from src.config.session import get_session, get_staging_db
 
 
 logger = logging.getLogger(__name__)
@@ -176,98 +175,31 @@ class EPMC:
         @self.router.post("/epmc/ingest-pmc-data", response_model=list[PMCArticleFull])
         async def ingest_pmc_data(
             keyword: str = Body(..., embed=True),
+            from_date: Optional[str] = Body(None, embed=True),
+            to_date: Optional[str] = Body(None, embed=True),
             staging_repo: EPMCRepo = Depends(get_staging_epmc_repo),
             production_repo: EPMCRepo = Depends(get_epmc_repo),
         ):
             service = EPMCService(staging_repo)
             grant_service = Grant(staging_repo)
 
-            # INGESTION_STARTED — fired before pull begins (no ingestion_id yet)
-            staging_repo.db.add(AuditLog(
-                event_type=AuditEventType.INGESTION_STARTED,
-                entity_type="ingestion",
-                new_value={"keyword": keyword, "run_type": "full"},
-                action_by="system",
-                action_at=datetime.now(timezone.utc),
-            ))
-            staging_repo.db.flush()
-
+            run_type = "delta" if from_date else service._detect_run_type()[0]
+            service.record_ingestion_started(keyword, run_type=run_type)
             try:
-                logger.info("Ingesting PMC data for keyword: %s", keyword)
-                result = service.insert_articles_by_keyword(keyword, created_by="system")
-                references_result = service.insert_references(created_by="system")
-                grant_result = grant_service.create_grants(keyword)
+                logger.info("Ingesting PMC data for keyword: %s run_type=%s", keyword, run_type)
+                service.insert_articles_by_keyword(keyword, created_by="system", from_date=from_date, to_date=to_date)
+                service.insert_references(created_by="system")
+                grant_service.create_grants(keyword)
 
-                # Classification — compare staged articles against production
-                classify_service = AutoClassifyService(
-                    staging_db=staging_repo.db,
-                    production_db=production_repo.db,
-                )
+                classify_service = AutoClassifyService(staging_repo, production_repo)
                 classify_result = classify_service.classify_ingestion_run(
                     ingestion_id=service.ingestion_id,
                     created_by="system",
                 )
-
-                # INGESTION_COMPLETED
-                staging_repo.db.add(AuditLog(
-                    event_type=AuditEventType.INGESTION_COMPLETED,
-                    entity_type="ingestion",
-                    entity_id=str(service.ingestion_id),
-                    ingestion_id=service.ingestion_id,
-                    new_value={
-                        "keyword": keyword,
-                        "articles": result.get("articles") if isinstance(result, dict) else result,
-                        "total_pulled": classify_result.total_pulled,
-                        "new_count": classify_result.new_count,
-                        "unchanged_count": classify_result.unchanged_count,
-                        "changed_count": classify_result.changed_count,
-                        "auto_approved_count": classify_result.auto_approved_count,
-                        "pending_review_count": classify_result.pending_review_count,
-                        "unresolvable_count": classify_result.unresolvable_count,
-                    },
-                    action_by="system",
-                    action_at=datetime.now(timezone.utc),
-                ))
-                staging_repo.db.flush()
-
-                # File-based log (best-effort)
-                try:
-                    log_entry = {
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
-                        "keyword": keyword,
-                        "articles": result,
-                        "references": references_result,
-                        "grants": grant_result,
-                        "classify": {
-                            "total_pulled": classify_result.total_pulled,
-                            "new": classify_result.new_count,
-                            "unchanged": classify_result.unchanged_count,
-                            "changed": classify_result.changed_count,
-                            "auto_approved": classify_result.auto_approved_count,
-                            "pending_review": classify_result.pending_review_count,
-                            "unresolvable": classify_result.unresolvable_count,
-                        },
-                    }
-                    with open("ingestion_log.txt", "a", encoding="utf-8") as lf:
-                        lf.write(json.dumps(log_entry, default=str) + "\n")
-                except Exception:
-                    pass
+                service.record_ingestion_completed(service.ingestion_id, keyword, classify_result)
 
             except Exception as e:
-                # INGESTION_FAILED — best-effort, don't let this mask the original error
-                try:
-                    staging_repo.db.add(AuditLog(
-                        event_type=AuditEventType.INGESTION_FAILED,
-                        entity_type="ingestion",
-                        entity_id=str(service.ingestion_id) if service.ingestion_id else None,
-                        ingestion_id=service.ingestion_id,
-                        new_value={"error": str(e), "keyword": keyword},
-                        action_by="system",
-                        action_at=datetime.now(timezone.utc),
-                    ))
-                    staging_repo.db.flush()
-                except Exception:
-                    pass
+                service.record_ingestion_failed(service.ingestion_id, keyword, str(e))
                 raise HTTPException(status_code=500, detail=f"Ingestion failed: {e}")
 
             articles = staging_repo.get_all_articles()

--- a/src/routers/epmc.py
+++ b/src/routers/epmc.py
@@ -9,7 +9,10 @@ from src.models.citation import Citation as CitationModel, CitationList, TotalCi
 from src.services.epmc import EPMCService as EPMCService
 from src.repositories.epmc import EPMCRepo as EPMCRepo
 from src.services.grant import GrantService as Grant
-from src.config.session import get_session, get_staging_db
+from src.services.auto_classify import AutoClassifyService
+from src.models.entities.audit_log import AuditLog
+from src.models.entities.enums import AuditEventType
+from src.config.session import get_session, get_staging_db, get_production_db
 
 
 logger = logging.getLogger(__name__)
@@ -173,37 +176,101 @@ class EPMC:
         @self.router.post("/epmc/ingest-pmc-data", response_model=list[PMCArticleFull])
         async def ingest_pmc_data(
             keyword: str = Body(..., embed=True),
-            repo: EPMCRepo = Depends(get_staging_epmc_repo),
+            staging_repo: EPMCRepo = Depends(get_staging_epmc_repo),
+            production_repo: EPMCRepo = Depends(get_epmc_repo),
         ):
-            service = EPMCService(repo)
-            grant_service = Grant(repo)
+            service = EPMCService(staging_repo)
+            grant_service = Grant(staging_repo)
+
+            # INGESTION_STARTED — fired before pull begins (no ingestion_id yet)
+            staging_repo.db.add(AuditLog(
+                event_type=AuditEventType.INGESTION_STARTED,
+                entity_type="ingestion",
+                new_value={"keyword": keyword, "run_type": "full"},
+                action_by="system",
+                action_at=datetime.now(timezone.utc),
+            ))
+            staging_repo.db.flush()
 
             try:
                 logger.info("Ingesting PMC data for keyword: %s", keyword)
                 result = service.insert_articles_by_keyword(keyword, created_by="system")
-                #citations_result = service.insert_citations(created_by="system")
                 references_result = service.insert_references(created_by="system")
                 grant_result = grant_service.create_grants(keyword)
 
-                # Write a JSON-line entry with ingestion results and timestamp.
+                # Classification — compare staged articles against production
+                classify_service = AutoClassifyService(
+                    staging_db=staging_repo.db,
+                    production_db=production_repo.db,
+                )
+                classify_result = classify_service.classify_ingestion_run(
+                    ingestion_id=service.ingestion_id,
+                    created_by="system",
+                )
+
+                # INGESTION_COMPLETED
+                staging_repo.db.add(AuditLog(
+                    event_type=AuditEventType.INGESTION_COMPLETED,
+                    entity_type="ingestion",
+                    entity_id=str(service.ingestion_id),
+                    ingestion_id=service.ingestion_id,
+                    new_value={
+                        "keyword": keyword,
+                        "articles": result.get("articles") if isinstance(result, dict) else result,
+                        "total_pulled": classify_result.total_pulled,
+                        "new_count": classify_result.new_count,
+                        "unchanged_count": classify_result.unchanged_count,
+                        "changed_count": classify_result.changed_count,
+                        "auto_approved_count": classify_result.auto_approved_count,
+                        "pending_review_count": classify_result.pending_review_count,
+                        "unresolvable_count": classify_result.unresolvable_count,
+                    },
+                    action_by="system",
+                    action_at=datetime.now(timezone.utc),
+                ))
+                staging_repo.db.flush()
+
+                # File-based log (best-effort)
                 try:
                     log_entry = {
                         "timestamp": datetime.now(timezone.utc).isoformat(),
                         "keyword": keyword,
                         "articles": result,
-                        #"citations": citations_result,
                         "references": references_result,
                         "grants": grant_result,
+                        "classify": {
+                            "total_pulled": classify_result.total_pulled,
+                            "new": classify_result.new_count,
+                            "unchanged": classify_result.unchanged_count,
+                            "changed": classify_result.changed_count,
+                            "auto_approved": classify_result.auto_approved_count,
+                            "pending_review": classify_result.pending_review_count,
+                            "unresolvable": classify_result.unresolvable_count,
+                        },
                     }
                     with open("ingestion_log.txt", "a", encoding="utf-8") as lf:
                         lf.write(json.dumps(log_entry, default=str) + "\n")
                 except Exception:
-                    # Don't let logging failures break ingestion
                     pass
+
             except Exception as e:
+                # INGESTION_FAILED — best-effort, don't let this mask the original error
+                try:
+                    staging_repo.db.add(AuditLog(
+                        event_type=AuditEventType.INGESTION_FAILED,
+                        entity_type="ingestion",
+                        entity_id=str(service.ingestion_id) if service.ingestion_id else None,
+                        ingestion_id=service.ingestion_id,
+                        new_value={"error": str(e), "keyword": keyword},
+                        action_by="system",
+                        action_at=datetime.now(timezone.utc),
+                    ))
+                    staging_repo.db.flush()
+                except Exception:
+                    pass
                 raise HTTPException(status_code=500, detail=f"Ingestion failed: {e}")
 
-            articles = repo.get_all_articles()
+            articles = staging_repo.get_all_articles()
             return [PMCArticleFull.model_validate(article) for article in articles]
 
         @self.router.post("/epmc/ingest-pmc-grants")

--- a/src/services/auto_classify.py
+++ b/src/services/auto_classify.py
@@ -1,17 +1,13 @@
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from sqlalchemy import select, update as sa_update
-from sqlalchemy.orm import Session
-
 from src.models.entities.audit_log import AuditLog
 from src.models.entities.enums import AuditEventType
-from src.models.entities.ingestion import Ingestion
-from src.models.entities.known_divergence import KnownDivergence
 from src.models.entities.pmc_article import PMCArticle
 from src.models.entities.pmc_review import PMCReview
+from src.repositories.epmc import EPMCRepo
 
 logger = logging.getLogger(__name__)
 
@@ -128,15 +124,14 @@ class AutoClassifyService:
     database and classifies each record as NEW, UNCHANGED, CHANGED, or
     KNOWN_DIVERGENCE.
 
-    Reads from staging_db (ingestion snapshot).
-    Reads from production_db (current curated state).
-    Writes pmc_review rows and audit_log events to staging_db.
-    Updates the ingestion row counts in staging_db at completion.
+    All DB reads/writes go through the repo layer — no raw session access.
+    staging_repo  — reads staged articles and known divergences; writes reviews and audit logs.
+    production_repo — reads curated production articles for comparison.
     """
 
-    def __init__(self, staging_db: Session, production_db: Session) -> None:
-        self.staging_db = staging_db
-        self.production_db = production_db
+    def __init__(self, staging_repo: EPMCRepo, production_repo: EPMCRepo) -> None:
+        self.staging_repo = staging_repo
+        self.production_repo = production_repo
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -150,7 +145,7 @@ class AutoClassifyService:
         result = ClassifyResult(ingestion_id=ingestion_id)
         logger.info("AutoClassifyService: starting classification for ingestion_id=%d", ingestion_id)
 
-        staged = self._load_staged_articles(ingestion_id)
+        staged = self.staging_repo.get_staged_articles(ingestion_id)
         result.total_pulled = len(staged)
 
         for staged_article in staged:
@@ -220,18 +215,18 @@ class AutoClassifyService:
                         ingestion_id=ingestion_id,
                         action_by=created_by,
                     )
-                    logger.debug(
+                    logger.info(
                         "CLASSIFICATION_UNCHANGED epmc_id=%s ingestion_id=%d",
                         staged_article.epmc_id or staged_article.doi, ingestion_id,
                     )
                 else:
-                    # Filter out fields already covered by active known divergences
+                    # Filter out fields covered by active known divergences
                     effective_diff = self._filter_known_divergences(
                         staged_article.epmc_id, staged_article.doi, full_diff
                     )
 
                     if not effective_diff:
-                        # All changed fields are known/accepted divergences — suppress
+                        # All changed fields are known divergences — suppress
                         result.changed_count += 1
                         result.known_divergence_count += 1
                         result.auto_approved_count += 1
@@ -259,7 +254,7 @@ class AutoClassifyService:
                             list(full_diff.keys()),
                         )
                     else:
-                        # CHANGED — check auto-approve rules against effective diff
+                        # CHANGED — check auto-approve rules
                         result.changed_count += 1
                         auto_approved, approve_reason = self._check_auto_approve(effective_diff)
 
@@ -297,8 +292,6 @@ class AutoClassifyService:
                             auto_approved,
                         )
 
-        self.staging_db.flush()
-
         # Summary audit log for the full run
         self._write_audit_log(
             event_type=AuditEventType.INGESTION_CLASSIFICATION_COMPLETE,
@@ -316,23 +309,17 @@ class AutoClassifyService:
                 "unresolvable_count": result.unresolvable_count,
             },
         )
-        self.staging_db.flush()
 
         # Write classification counts back to the ingestion row
-        self.staging_db.execute(
-            sa_update(Ingestion)
-            .where(Ingestion.id == ingestion_id)
-            .values(
-                total_pulled=result.total_pulled,
-                new_count=result.new_count,
-                unchanged_count=result.unchanged_count,
-                changed_count=result.changed_count,
-                auto_approved_count=result.auto_approved_count,
-                pending_review_count=result.pending_review_count,
-                unresolvable_count=result.unresolvable_count,
-            )
-        )
-        self.staging_db.flush()
+        self.staging_repo.update_ingestion_counts(ingestion_id, {
+            "total_pulled": result.total_pulled,
+            "new_count": result.new_count,
+            "unchanged_count": result.unchanged_count,
+            "changed_count": result.changed_count,
+            "auto_approved_count": result.auto_approved_count,
+            "pending_review_count": result.pending_review_count,
+            "unresolvable_count": result.unresolvable_count,
+        })
 
         logger.info(
             "AutoClassifyService: classification complete ingestion_id=%d result=%s",
@@ -355,7 +342,7 @@ class AutoClassifyService:
         auto_approve_reason: Optional[str],
         review_status: str,
         created_by: str,
-    ) -> None:
+    ) -> int:
         review = PMCReview(
             ingestion_id=ingestion_id,
             staging_id=staged.id,
@@ -369,7 +356,7 @@ class AutoClassifyService:
             created_by=created_by,
             created_at=datetime.now(timezone.utc),
         )
-        self.staging_db.add(review)
+        return self.staging_repo.insert_review(review)
 
     # ------------------------------------------------------------------
     # Audit log writer
@@ -398,7 +385,7 @@ class AutoClassifyService:
             action_by=action_by,
             action_at=datetime.now(timezone.utc),
         )
-        self.staging_db.add(log)
+        self.staging_repo.insert_audit_log(log)
 
     # ------------------------------------------------------------------
     # Known divergence filter
@@ -411,37 +398,27 @@ class AutoClassifyService:
         diff: Dict[str, Any],
     ) -> Dict[str, Any]:
         """
-        Remove fields from diff that are already covered by an active known_divergence.
+        Remove fields from diff already covered by an active known_divergence.
 
         A field is suppressed when:
           - known_divergences has an active row for this article + field_path
-          - the epmc_value on that row matches the incoming new value from EPMC
+          - epmc_value matches the incoming new value from EPMC
 
-        If EPMC starts sending a different value than the one we previously
-        rejected, the divergence no longer suppresses — it surfaces for review.
+        If EPMC starts sending a different value the suppression lifts.
         """
         if not diff:
             return diff
 
-        query = select(KnownDivergence).where(KnownDivergence.active.is_(True))
-        if epmc_id:
-            query = query.where(KnownDivergence.epmc_id == epmc_id)
-        elif doi:
-            query = query.where(KnownDivergence.doi == doi)
-        else:
-            return diff
-
-        known = self.staging_db.execute(query).scalars().all()
+        known = self.staging_repo.get_active_known_divergences(epmc_id, doi)
         if not known:
             return diff
 
-        known_index: Dict[str, KnownDivergence] = {kd.field_path: kd for kd in known}
-
+        known_index = {kd.field_path: kd for kd in known}
         filtered: Dict[str, Any] = {}
+
         for field_name, change in diff.items():
             kd = known_index.get(field_name)
             if kd and str(change["new"]) == str(kd.epmc_value):
-                # EPMC is still sending the same value we already rejected — suppress
                 logger.debug(
                     "KNOWN_DIVERGENCE_SUPPRESSED epmc_id=%s field=%s epmc_value=%s",
                     epmc_id or doi, field_name, kd.epmc_value,
@@ -455,12 +432,9 @@ class AutoClassifyService:
     # Diff helpers
     # ------------------------------------------------------------------
 
-    def _compute_diff(
-        self, prod: PMCArticle, staged: PMCArticle
-    ) -> Dict[str, Any]:
+    def _compute_diff(self, prod: PMCArticle, staged: PMCArticle) -> Dict[str, Any]:
         """
-        Return a dict of fields that differ between prod and staged.
-        Format: {field: {"old": <prod_value>, "new": <staged_value>}}
+        Return {field: {"old": prod_value, "new": staged_value}} for changed fields.
         Empty dict means no differences.
         """
         diff: Dict[str, Any] = {}
@@ -471,14 +445,11 @@ class AutoClassifyService:
                 diff[field_name] = {"old": _serialise(old_val), "new": _serialise(new_val)}
         return diff
 
-    def _check_auto_approve(
-        self, diff: Dict[str, Any]
-    ) -> Tuple[bool, Optional[str]]:
+    def _check_auto_approve(self, diff: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
         """
         Returns (auto_approved, reason_label).
-        A diff is auto-approved only when EVERY changed field is covered by
-        a rule whose predicate returns True.
-        With an empty rule list (v1) this always returns (False, None).
+        Every changed field must be covered by a passing rule.
+        Empty rule list (v1) always returns (False, None).
         """
         if not AUTO_APPROVE_RULES:
             return False, None
@@ -498,46 +469,38 @@ class AutoClassifyService:
     # Match helpers
     # ------------------------------------------------------------------
 
-    def _load_staged_articles(self, ingestion_id: int) -> List[PMCArticle]:
-        """Return all pmc_articles rows written in this ingestion run."""
-        return (
-            self.staging_db.execute(
-                select(PMCArticle).where(PMCArticle.ingestion_id == ingestion_id)
-            )
-            .scalars()
-            .all()
-        )
-
-    def _find_in_production(
-        self, staged: PMCArticle
-    ) -> Tuple[Optional[PMCArticle], str]:
+    def _find_in_production(self, staged: PMCArticle) -> Tuple[Optional[PMCArticle], str]:
         """
-        Look up the staged article in the production DB.
-
         Match strategy:
-          1. epmc_id (primary — stable EPMC identifier)
-          2. doi     (fallback — used when epmc_id absent)
-          3. Neither present → (None, "unresolvable")
+          1. epmc_id  — primary stable identifier
+          2. doi      — fallback
+          3. Neither  → "unresolvable"
 
-        Returns:
-          (production_article, match_key) where match_key is one of:
-            "epmc_id"       — matched on epmc_id
-            "doi"           — matched on doi
-            "new"           — no match found (record is new to production)
-            "unresolvable"  — neither epmc_id nor doi present on staged article
+        Returns (article, match_key) where match_key is one of:
+          "epmc_id", "doi", "new", "unresolvable"
         """
         if staged.epmc_id:
-            prod = self.production_db.execute(
-                select(PMCArticle).where(PMCArticle.epmc_id == staged.epmc_id)
-            ).scalar_one_or_none()
-            return (prod, "epmc_id" if prod else "new")
+            prod = self.production_repo.get_article_by_epmc_id(staged.epmc_id)
+            match_key = "epmc_id" if prod else "new"
+            logger.info(
+                "PRODUCTION_MATCH epmc_id=%s match_key=%s found=%s",
+                staged.epmc_id, match_key, prod is not None,
+            )
+            return (prod, match_key)
 
         if staged.doi:
-            prod = self.production_db.execute(
-                select(PMCArticle).where(PMCArticle.doi == staged.doi)
-            ).scalar_one_or_none()
-            return (prod, "doi" if prod else "new")
+            prod = self.production_repo.get_article_by_doi(staged.doi)
+            match_key = "doi" if prod else "new"
+            logger.info(
+                "PRODUCTION_MATCH doi=%s match_key=%s found=%s",
+                staged.doi, match_key, prod is not None,
+            )
+            return (prod, match_key)
 
+        logger.warning(
+            "PRODUCTION_MATCH_UNRESOLVABLE staging_id=%s — no epmc_id or doi",
+            staged.id,
+        )
         return (None, "unresolvable")
 
 

--- a/src/services/auto_classify.py
+++ b/src/services/auto_classify.py
@@ -1,11 +1,13 @@
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from src.models.entities.audit_log import AuditLog
+from src.models.entities.known_divergence import KnownDivergence
 from src.models.entities.pmc_article import PMCArticle
 from src.models.entities.pmc_review import PMCReview
 
@@ -112,6 +114,7 @@ class ClassifyResult:
     new_count: int = 0
     unchanged_count: int = 0
     changed_count: int = 0
+    known_divergence_count: int = 0
     auto_approved_count: int = 0
     pending_review_count: int = 0
     unresolvable_count: int = 0
@@ -120,11 +123,12 @@ class ClassifyResult:
 class AutoClassifyService:
     """
     Compares every article from a completed ingestion run against the production
-    database and classifies each record as NEW, UNCHANGED, or CHANGED.
+    database and classifies each record as NEW, UNCHANGED, CHANGED, or
+    KNOWN_DIVERGENCE.
 
     Reads from staging_db (ingestion snapshot).
     Reads from production_db (current curated state).
-    Writes pmc_review rows to staging_db.
+    Writes pmc_review rows and audit_log events to staging_db.
     Updates the ingestion row counts in staging_db at completion.
     """
 
@@ -152,8 +156,14 @@ class AutoClassifyService:
 
             if match_key == "unresolvable":
                 result.unresolvable_count += 1
+                self._write_audit_log(
+                    event_type="ARTICLE_UNRESOLVABLE",
+                    staged=staged_article,
+                    ingestion_id=ingestion_id,
+                    action_by=created_by,
+                )
                 logger.warning(
-                    "COMPARISON_UNRESOLVABLE ingestion_id=%d article.id=%d",
+                    "CLASSIFICATION_UNRESOLVABLE ingestion_id=%d article.id=%d",
                     ingestion_id, staged_article.id,
                 )
                 continue
@@ -172,15 +182,23 @@ class AutoClassifyService:
                     review_status="pending",
                     created_by=created_by,
                 )
+                self._write_audit_log(
+                    event_type="ARTICLE_CLASSIFIED_NEW",
+                    staged=staged_article,
+                    ingestion_id=ingestion_id,
+                    action_by=created_by,
+                    new_value={"title": staged_article.title, "epmc_id": staged_article.epmc_id},
+                )
                 logger.info(
                     "CLASSIFICATION_NEW epmc_id=%s ingestion_id=%d",
                     staged_article.epmc_id or staged_article.doi, ingestion_id,
                 )
+
             else:
                 # ---- UNCHANGED or CHANGED ------------------------------
-                diff = self._compute_diff(prod_article, staged_article)
+                full_diff = self._compute_diff(prod_article, staged_article)
 
-                if not diff:
+                if not full_diff:
                     # UNCHANGED
                     result.unchanged_count += 1
                     result.auto_approved_count += 1
@@ -194,43 +212,110 @@ class AutoClassifyService:
                         review_status="approved",
                         created_by=created_by,
                     )
+                    self._write_audit_log(
+                        event_type="ARTICLE_CLASSIFIED_UNCHANGED",
+                        staged=staged_article,
+                        ingestion_id=ingestion_id,
+                        action_by=created_by,
+                    )
                     logger.debug(
                         "CLASSIFICATION_UNCHANGED epmc_id=%s ingestion_id=%d",
                         staged_article.epmc_id or staged_article.doi, ingestion_id,
                     )
                 else:
-                    # CHANGED — check auto-approve rules
-                    result.changed_count += 1
-                    auto_approved, approve_reason = self._check_auto_approve(diff)
+                    # Filter out fields already covered by active known divergences
+                    effective_diff = self._filter_known_divergences(
+                        staged_article.epmc_id, staged_article.doi, full_diff
+                    )
 
-                    if auto_approved:
+                    if not effective_diff:
+                        # All changed fields are known/accepted divergences — suppress
+                        result.changed_count += 1
+                        result.known_divergence_count += 1
                         result.auto_approved_count += 1
-                        review_status = "approved"
+                        self._write_review(
+                            ingestion_id=ingestion_id,
+                            staged=staged_article,
+                            review_type="changed",
+                            diff=full_diff,
+                            auto_approved=True,
+                            auto_approve_reason="known_divergences",
+                            review_status="approved",
+                            created_by=created_by,
+                        )
+                        self._write_audit_log(
+                            event_type="ARTICLE_CLASSIFIED_KNOWN_DIVERGENCE",
+                            staged=staged_article,
+                            ingestion_id=ingestion_id,
+                            action_by=created_by,
+                            new_value={"suppressed_fields": list(full_diff.keys())},
+                        )
+                        logger.info(
+                            "CLASSIFICATION_KNOWN_DIVERGENCE epmc_id=%s ingestion_id=%d fields=%s",
+                            staged_article.epmc_id or staged_article.doi,
+                            ingestion_id,
+                            list(full_diff.keys()),
+                        )
                     else:
-                        result.pending_review_count += 1
-                        review_status = "pending"
+                        # CHANGED — check auto-approve rules against effective diff
+                        result.changed_count += 1
+                        auto_approved, approve_reason = self._check_auto_approve(effective_diff)
 
-                    self._write_review(
-                        ingestion_id=ingestion_id,
-                        staged=staged_article,
-                        review_type="changed",
-                        diff=diff,
-                        auto_approved=auto_approved,
-                        auto_approve_reason=approve_reason,
-                        review_status=review_status,
-                        created_by=created_by,
-                    )
-                    logger.info(
-                        "CLASSIFICATION_CHANGED epmc_id=%s ingestion_id=%d fields=%s auto_approved=%s",
-                        staged_article.epmc_id or staged_article.doi,
-                        ingestion_id,
-                        list(diff.keys()),
-                        auto_approved,
-                    )
+                        if auto_approved:
+                            result.auto_approved_count += 1
+                            review_status = "approved"
+                        else:
+                            result.pending_review_count += 1
+                            review_status = "pending"
+
+                        self._write_review(
+                            ingestion_id=ingestion_id,
+                            staged=staged_article,
+                            review_type="changed",
+                            diff=effective_diff,
+                            auto_approved=auto_approved,
+                            auto_approve_reason=approve_reason,
+                            review_status=review_status,
+                            created_by=created_by,
+                        )
+                        self._write_audit_log(
+                            event_type="ARTICLE_CLASSIFIED_CHANGED",
+                            staged=staged_article,
+                            ingestion_id=ingestion_id,
+                            action_by=created_by,
+                            old_value={f: effective_diff[f]["old"] for f in effective_diff},
+                            new_value={f: effective_diff[f]["new"] for f in effective_diff},
+                            comment=f"auto_approved={auto_approved}",
+                        )
+                        logger.info(
+                            "CLASSIFICATION_CHANGED epmc_id=%s ingestion_id=%d fields=%s auto_approved=%s",
+                            staged_article.epmc_id or staged_article.doi,
+                            ingestion_id,
+                            list(effective_diff.keys()),
+                            auto_approved,
+                        )
 
         self.staging_db.flush()
 
-        # TODO Step 5: audit log events
+        # Summary audit log for the full run
+        self._write_audit_log(
+            event_type="INGESTION_CLASSIFICATION_COMPLETE",
+            staged=None,
+            ingestion_id=ingestion_id,
+            action_by=created_by,
+            new_value={
+                "total_pulled": result.total_pulled,
+                "new_count": result.new_count,
+                "unchanged_count": result.unchanged_count,
+                "changed_count": result.changed_count,
+                "known_divergence_count": result.known_divergence_count,
+                "auto_approved_count": result.auto_approved_count,
+                "pending_review_count": result.pending_review_count,
+                "unresolvable_count": result.unresolvable_count,
+            },
+        )
+        self.staging_db.flush()
+
         # TODO Step 6: write ingestion counts
 
         logger.info(
@@ -271,6 +356,86 @@ class AutoClassifyService:
         self.staging_db.add(review)
 
     # ------------------------------------------------------------------
+    # Audit log writer
+    # ------------------------------------------------------------------
+
+    def _write_audit_log(
+        self,
+        event_type: str,
+        staged: Optional[PMCArticle],
+        ingestion_id: int,
+        action_by: str = "system",
+        old_value: Optional[Dict[str, Any]] = None,
+        new_value: Optional[Dict[str, Any]] = None,
+        comment: Optional[str] = None,
+    ) -> None:
+        log = AuditLog(
+            event_type=event_type,
+            entity_type="pmc_article" if staged is not None else "ingestion",
+            entity_id=str(staged.id) if staged is not None else str(ingestion_id),
+            epmc_id=staged.epmc_id if staged is not None else None,
+            doi=staged.doi if staged is not None else None,
+            ingestion_id=ingestion_id,
+            old_value=old_value,
+            new_value=new_value,
+            comment=comment,
+            action_by=action_by,
+            action_at=datetime.now(timezone.utc),
+        )
+        self.staging_db.add(log)
+
+    # ------------------------------------------------------------------
+    # Known divergence filter
+    # ------------------------------------------------------------------
+
+    def _filter_known_divergences(
+        self,
+        epmc_id: Optional[str],
+        doi: Optional[str],
+        diff: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Remove fields from diff that are already covered by an active known_divergence.
+
+        A field is suppressed when:
+          - known_divergences has an active row for this article + field_path
+          - the epmc_value on that row matches the incoming new value from EPMC
+
+        If EPMC starts sending a different value than the one we previously
+        rejected, the divergence no longer suppresses — it surfaces for review.
+        """
+        if not diff:
+            return diff
+
+        query = select(KnownDivergence).where(KnownDivergence.active.is_(True))
+        if epmc_id:
+            query = query.where(KnownDivergence.epmc_id == epmc_id)
+        elif doi:
+            query = query.where(KnownDivergence.doi == doi)
+        else:
+            return diff
+
+        known = self.staging_db.execute(query).scalars().all()
+        if not known:
+            return diff
+
+        known_index: Dict[str, KnownDivergence] = {kd.field_path: kd for kd in known}
+
+        filtered: Dict[str, Any] = {}
+        for field_name, change in diff.items():
+            kd = known_index.get(field_name)
+            if kd and str(change["new"]) == str(kd.epmc_value):
+                # EPMC is still sending the same value we already rejected — suppress
+                logger.debug(
+                    "KNOWN_DIVERGENCE_SUPPRESSED epmc_id=%s field=%s epmc_value=%s",
+                    epmc_id or doi, field_name, kd.epmc_value,
+                )
+                continue
+            filtered[field_name] = change
+
+        return filtered
+
+    # ------------------------------------------------------------------
     # Diff helpers
     # ------------------------------------------------------------------
 
@@ -283,11 +448,11 @@ class AutoClassifyService:
         Empty dict means no differences.
         """
         diff: Dict[str, Any] = {}
-        for field in DIFFABLE_FIELDS:
-            old_val = getattr(prod, field, None)
-            new_val = getattr(staged, field, None)
+        for field_name in DIFFABLE_FIELDS:
+            old_val = getattr(prod, field_name, None)
+            new_val = getattr(staged, field_name, None)
             if old_val != new_val:
-                diff[field] = {"old": _serialise(old_val), "new": _serialise(new_val)}
+                diff[field_name] = {"old": _serialise(old_val), "new": _serialise(new_val)}
         return diff
 
     def _check_auto_approve(
@@ -305,8 +470,8 @@ class AutoClassifyService:
         rule_index: Dict[str, AutoApproveRule] = {r.field: r for r in AUTO_APPROVE_RULES}
         matched_labels: List[str] = []
 
-        for field, change in diff.items():
-            rule = rule_index.get(field)
+        for field_name, change in diff.items():
+            rule = rule_index.get(field_name)
             if rule is None or not rule.applies(change["old"], change["new"]):
                 return False, None
             matched_labels.append(rule.label)

--- a/src/services/auto_classify.py
+++ b/src/services/auto_classify.py
@@ -115,6 +115,7 @@ class ClassifyResult:
     known_divergence_count: int = 0
     auto_approved_count: int = 0
     pending_review_count: int = 0
+    skipped_count: int = 0   # in production but not in delta window — no review needed
     unresolvable_count: int = 0
 
 
@@ -137,13 +138,31 @@ class AutoClassifyService:
     # Public entry point
     # ------------------------------------------------------------------
 
-    def classify_ingestion_run(self, ingestion_id: int, created_by: str = "system") -> ClassifyResult:
+    def classify_ingestion_run(
+        self,
+        ingestion_id: int,
+        delta_epmc_ids: Optional[set] = None,
+        created_by: str = "system",
+    ) -> ClassifyResult:
         """
-        Entry point. Classifies all articles written in this ingestion run.
+        Entry point. Classifies all articles written in Phase 2 (full pull).
+
+        delta_epmc_ids: set of epmc_ids returned by Phase 1 (delta pull).
+          - If an article's epmc_id is in this set → it was updated since last ingestion
+            → run field diff against production (UNCHANGED or CHANGED).
+          - If an article's epmc_id is NOT in this set and it exists in production
+            → it was not updated → skip (no review row, no diff).
+          - If None → no prior ingestion existed → same skip logic applies (baseline run).
+          - If not in production at all → NEW regardless.
+
         Returns a ClassifyResult with per-category counts.
         """
         result = ClassifyResult(ingestion_id=ingestion_id)
-        logger.info("AutoClassifyService: starting classification for ingestion_id=%d", ingestion_id)
+        logger.info(
+            "AutoClassifyService: starting classification ingestion_id=%d delta_ids=%s",
+            ingestion_id,
+            f"{len(delta_epmc_ids)} articles" if delta_epmc_ids is not None else "none (first run)",
+        )
 
         staged = self.staging_repo.get_staged_articles(ingestion_id)
         result.total_pulled = len(staged)
@@ -169,46 +188,48 @@ class AutoClassifyService:
                 # ---- NEW -----------------------------------------------
                 result.new_count += 1
                 result.pending_review_count += 1
-                self._write_review(
-                    ingestion_id=ingestion_id,
-                    staged=staged_article,
-                    review_type="new",
-                    diff=None,
-                    auto_approved=False,
-                    auto_approve_reason=None,
-                    review_status="pending",
-                    created_by=created_by,
-                )
-                self._write_audit_log(
-                    event_type=AuditEventType.ARTICLE_CLASSIFIED_NEW,
-                    staged=staged_article,
-                    ingestion_id=ingestion_id,
-                    action_by=created_by,
-                    new_value={"title": staged_article.title, "epmc_id": staged_article.epmc_id},
-                )
-                logger.info(
-                    "CLASSIFICATION_NEW epmc_id=%s ingestion_id=%d",
-                    staged_article.epmc_id or staged_article.doi, ingestion_id,
-                )
 
-            else:
-                # ---- UNCHANGED or CHANGED ------------------------------
-                full_diff = self._compute_diff(prod_article, staged_article)
-
-                if not full_diff:
-                    # UNCHANGED
-                    result.unchanged_count += 1
-                    result.auto_approved_count += 1
+                existing = self.staging_repo.get_pending_review_by_epmc_id(staged_article.epmc_id)
+                if existing:
+                    # Already in the review queue from a prior ingestion — don't duplicate.
+                    logger.info(
+                        "CLASSIFICATION_NEW_ALREADY_QUEUED epmc_id=%s review_id=%d — skipping",
+                        staged_article.epmc_id or staged_article.doi, existing.id,
+                    )
+                else:
                     self._write_review(
                         ingestion_id=ingestion_id,
                         staged=staged_article,
-                        review_type="unchanged",
+                        review_type="new",
                         diff=None,
-                        auto_approved=True,
-                        auto_approve_reason="no_changes_detected",
-                        review_status="approved",
+                        auto_approved=False,
+                        auto_approve_reason=None,
+                        review_status="pending",
                         created_by=created_by,
                     )
+                    self._write_audit_log(
+                        event_type=AuditEventType.ARTICLE_CLASSIFIED_NEW,
+                        staged=staged_article,
+                        ingestion_id=ingestion_id,
+                        action_by=created_by,
+                        new_value={"title": staged_article.title, "epmc_id": staged_article.epmc_id},
+                    )
+                    logger.info(
+                        "CLASSIFICATION_NEW epmc_id=%s ingestion_id=%d",
+                        staged_article.epmc_id or staged_article.doi, ingestion_id,
+                    )
+
+            elif delta_epmc_ids is not None and staged_article.epmc_id in delta_epmc_ids:
+                # ---- UNCHANGED or CHANGED ------------------------------
+                # Article was in the Phase 1 delta pull → it was updated since last
+                # ingestion → run field diff to determine the exact classification.
+                full_diff = self._compute_diff(prod_article, staged_article)
+
+                if not full_diff:
+                    # UNCHANGED — delta-flagged but no field changes against production.
+                    # No pmc_review row needed; audit log provides traceability.
+                    result.unchanged_count += 1
+                    result.auto_approved_count += 1
                     self._write_audit_log(
                         event_type=AuditEventType.ARTICLE_CLASSIFIED_UNCHANGED,
                         staged=staged_article,
@@ -265,16 +286,40 @@ class AutoClassifyService:
                             result.pending_review_count += 1
                             review_status = "pending"
 
-                        self._write_review(
-                            ingestion_id=ingestion_id,
-                            staged=staged_article,
-                            review_type="changed",
-                            diff=effective_diff,
-                            auto_approved=auto_approved,
-                            auto_approve_reason=approve_reason,
-                            review_status=review_status,
-                            created_by=created_by,
+                        existing = self.staging_repo.get_pending_review_by_epmc_id(
+                            staged_article.epmc_id
                         )
+                        if existing:
+                            # Refresh the stale pending row with the latest diff and
+                            # staging pointer — curator always reviews the freshest data.
+                            self.staging_repo.update_review(existing.id, {
+                                "ingestion_id": ingestion_id,
+                                "staging_id": staged_article.id,
+                                "review_type": "changed",
+                                "diff": effective_diff,
+                                "auto_approved": auto_approved,
+                                "auto_approve_reason": approve_reason,
+                                "review_status": review_status,
+                            })
+                            logger.info(
+                                "CLASSIFICATION_CHANGED_REVIEW_REFRESHED epmc_id=%s "
+                                "review_id=%d fields=%s",
+                                staged_article.epmc_id or staged_article.doi,
+                                existing.id,
+                                list(effective_diff.keys()),
+                            )
+                        else:
+                            self._write_review(
+                                ingestion_id=ingestion_id,
+                                staged=staged_article,
+                                review_type="changed",
+                                diff=effective_diff,
+                                auto_approved=auto_approved,
+                                auto_approve_reason=approve_reason,
+                                review_status=review_status,
+                                created_by=created_by,
+                            )
+
                         self._write_audit_log(
                             event_type=AuditEventType.ARTICLE_CLASSIFIED_CHANGED,
                             staged=staged_article,
@@ -282,7 +327,7 @@ class AutoClassifyService:
                             action_by=created_by,
                             old_value={f: effective_diff[f]["old"] for f in effective_diff},
                             new_value={f: effective_diff[f]["new"] for f in effective_diff},
-                            comment=f"auto_approved={auto_approved}",
+                            comment=f"auto_approved={auto_approved} refreshed={existing is not None}",
                         )
                         logger.info(
                             "CLASSIFICATION_CHANGED epmc_id=%s ingestion_id=%d fields=%s auto_approved=%s",
@@ -291,6 +336,18 @@ class AutoClassifyService:
                             list(effective_diff.keys()),
                             auto_approved,
                         )
+
+            else:
+                # ---- SKIPPED ------------------------------------------
+                # Article is in production but was NOT in the Phase 1 delta pull.
+                # It has not been updated since the last ingestion — no diff needed.
+                # No pmc_review row written; only counted for audit purposes.
+                result.skipped_count += 1
+                logger.debug(
+                    "CLASSIFICATION_SKIPPED epmc_id=%s ingestion_id=%d "
+                    "(in production, not in delta window)",
+                    staged_article.epmc_id or staged_article.doi, ingestion_id,
+                )
 
         # Summary audit log for the full run
         self._write_audit_log(
@@ -306,15 +363,17 @@ class AutoClassifyService:
                 "known_divergence_count": result.known_divergence_count,
                 "auto_approved_count": result.auto_approved_count,
                 "pending_review_count": result.pending_review_count,
+                "skipped_count": result.skipped_count,
                 "unresolvable_count": result.unresolvable_count,
             },
         )
 
-        # Write classification counts back to the ingestion row
+        # Write classification counts back to the ingestion row.
+        # skipped_count stored in unchanged_count (no dedicated DB column yet).
         self.staging_repo.update_ingestion_counts(ingestion_id, {
             "total_pulled": result.total_pulled,
             "new_count": result.new_count,
-            "unchanged_count": result.unchanged_count,
+            "unchanged_count": result.unchanged_count + result.skipped_count,
             "changed_count": result.changed_count,
             "auto_approved_count": result.auto_approved_count,
             "pending_review_count": result.pending_review_count,
@@ -322,9 +381,12 @@ class AutoClassifyService:
         })
 
         logger.info(
-            "AutoClassifyService: classification complete ingestion_id=%d result=%s",
+            "AutoClassifyService: classification complete ingestion_id=%d "
+            "total=%d new=%d unchanged=%d changed=%d skipped=%d pending_review=%d",
             ingestion_id,
-            result,
+            result.total_pulled, result.new_count,
+            result.unchanged_count, result.changed_count,
+            result.skipped_count, result.pending_review_count,
         )
         return result
 

--- a/src/services/auto_classify.py
+++ b/src/services/auto_classify.py
@@ -1,0 +1,78 @@
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Auto-approve rules
+#
+# Each rule is a dict with:
+#   field   — the pmc_articles column name this rule applies to
+#   label   — short human-readable name logged in auto_approve_reason
+#   applies — callable(old_value, new_value) -> bool
+#              returns True when the change is safe to auto-approve
+#
+# Leave this list empty for v1. Add rules here as patterns emerge from
+# real ingestion runs — no structural code changes needed to add one.
+#
+# Example (do not activate until confirmed with stakeholders):
+#   {
+#       "field": "cited_by_count",
+#       "label": "citation_count_increase",
+#       "applies": lambda old, new: isinstance(new, int) and isinstance(old, int) and new > old,
+#   }
+# ---------------------------------------------------------------------------
+AUTO_APPROVE_RULES: List[Dict[str, Any]] = []
+
+
+@dataclass
+class ClassifyResult:
+    ingestion_id: int
+    total_pulled: int = 0
+    new_count: int = 0
+    unchanged_count: int = 0
+    changed_count: int = 0
+    auto_approved_count: int = 0
+    pending_review_count: int = 0
+    unresolvable_count: int = 0
+
+
+class AutoClassifyService:
+    """
+    Compares every article from a completed ingestion run against the production
+    database and classifies each record as NEW, UNCHANGED, or CHANGED.
+
+    Reads from staging_db (ingestion snapshot).
+    Reads from production_db (current curated state).
+    Writes pmc_review rows and audit_log events to staging_db.
+    Updates the ingestion row counts in staging_db at completion.
+    """
+
+    def __init__(self, staging_db: Session, production_db: Session) -> None:
+        self.staging_db = staging_db
+        self.production_db = production_db
+
+    def classify_ingestion_run(self, ingestion_id: int) -> ClassifyResult:
+        """
+        Entry point. Classifies all articles written in this ingestion run.
+        Returns a ClassifyResult with per-category counts.
+        """
+        result = ClassifyResult(ingestion_id=ingestion_id)
+        logger.info("AutoClassifyService: starting classification for ingestion_id=%d", ingestion_id)
+
+        # TODO Step 3: load staged articles for this ingestion_id
+        # TODO Step 3: for each article, match against production
+        # TODO Step 4: route to NEW / UNCHANGED / CHANGED branch
+        # TODO Step 5: known divergence check + audit log events
+        # TODO Step 6: write ingestion counts
+
+        logger.info(
+            "AutoClassifyService: classification complete ingestion_id=%d result=%s",
+            ingestion_id,
+            result,
+        )
+        return result

--- a/src/services/auto_classify.py
+++ b/src/services/auto_classify.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from src.models.entities.audit_log import AuditLog
+from src.models.entities.enums import AuditEventType
 from src.models.entities.known_divergence import KnownDivergence
 from src.models.entities.pmc_article import PMCArticle
 from src.models.entities.pmc_review import PMCReview
@@ -157,7 +158,7 @@ class AutoClassifyService:
             if match_key == "unresolvable":
                 result.unresolvable_count += 1
                 self._write_audit_log(
-                    event_type="ARTICLE_UNRESOLVABLE",
+                    event_type=AuditEventType.ARTICLE_UNRESOLVABLE,
                     staged=staged_article,
                     ingestion_id=ingestion_id,
                     action_by=created_by,
@@ -183,7 +184,7 @@ class AutoClassifyService:
                     created_by=created_by,
                 )
                 self._write_audit_log(
-                    event_type="ARTICLE_CLASSIFIED_NEW",
+                    event_type=AuditEventType.ARTICLE_CLASSIFIED_NEW,
                     staged=staged_article,
                     ingestion_id=ingestion_id,
                     action_by=created_by,
@@ -213,7 +214,7 @@ class AutoClassifyService:
                         created_by=created_by,
                     )
                     self._write_audit_log(
-                        event_type="ARTICLE_CLASSIFIED_UNCHANGED",
+                        event_type=AuditEventType.ARTICLE_CLASSIFIED_UNCHANGED,
                         staged=staged_article,
                         ingestion_id=ingestion_id,
                         action_by=created_by,
@@ -244,7 +245,7 @@ class AutoClassifyService:
                             created_by=created_by,
                         )
                         self._write_audit_log(
-                            event_type="ARTICLE_CLASSIFIED_KNOWN_DIVERGENCE",
+                            event_type=AuditEventType.ARTICLE_CLASSIFIED_KNOWN_DIV,
                             staged=staged_article,
                             ingestion_id=ingestion_id,
                             action_by=created_by,
@@ -279,7 +280,7 @@ class AutoClassifyService:
                             created_by=created_by,
                         )
                         self._write_audit_log(
-                            event_type="ARTICLE_CLASSIFIED_CHANGED",
+                            event_type=AuditEventType.ARTICLE_CLASSIFIED_CHANGED,
                             staged=staged_article,
                             ingestion_id=ingestion_id,
                             action_by=created_by,
@@ -299,7 +300,7 @@ class AutoClassifyService:
 
         # Summary audit log for the full run
         self._write_audit_log(
-            event_type="INGESTION_CLASSIFICATION_COMPLETE",
+            event_type=AuditEventType.INGESTION_CLASSIFICATION_COMPLETE,
             staged=None,
             ingestion_id=ingestion_id,
             action_by=created_by,
@@ -361,7 +362,7 @@ class AutoClassifyService:
 
     def _write_audit_log(
         self,
-        event_type: str,
+        event_type: AuditEventType,
         staged: Optional[PMCArticle],
         ingestion_id: int,
         action_by: str = "system",

--- a/src/services/auto_classify.py
+++ b/src/services/auto_classify.py
@@ -1,34 +1,108 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from src.models.entities.pmc_article import PMCArticle
+from src.models.entities.pmc_review import PMCReview
 
 logger = logging.getLogger(__name__)
 
+
 # ---------------------------------------------------------------------------
-# Auto-approve rules
-#
-# Each rule is a dict with:
-#   field   — the pmc_articles column name this rule applies to
-#   label   — short human-readable name logged in auto_approve_reason
-#   applies — callable(old_value, new_value) -> bool
-#              returns True when the change is safe to auto-approve
-#
-# Leave this list empty for v1. Add rules here as patterns emerge from
-# real ingestion runs — no structural code changes needed to add one.
-#
-# Example (do not activate until confirmed with stakeholders):
-#   {
-#       "field": "cited_by_count",
-#       "label": "citation_count_increase",
-#       "applies": lambda old, new: isinstance(new, int) and isinstance(old, int) and new > old,
-#   }
+# Auto-approve rule contract
 # ---------------------------------------------------------------------------
-AUTO_APPROVE_RULES: List[Dict[str, Any]] = []
+
+@dataclass
+class AutoApproveRule:
+    """
+    Declares when a single-field change is safe to auto-approve.
+
+    field   — exact pmc_articles column name this rule covers
+    label   — short slug written to auto_approve_reason on the pmc_review row
+    applies — predicate(old_value, new_value) -> bool
+              return True  → change is safe, counts toward auto-approval
+              return False → change needs human review
+
+    A CHANGED record is auto-approved only when EVERY field in its diff
+    is covered by a rule whose predicate returns True. One uncovered or
+    failing field blocks auto-approval for the whole record.
+    """
+    field: str
+    label: str
+    applies: Callable[[Any, Any], bool]
+
+
+# ---------------------------------------------------------------------------
+# Active rules — empty for v1 / Phase 1.
+#
+# HOW TO ADD A RULE (no other code changes needed):
+#   1. Uncomment one of the ready-made examples below, or write a new one.
+#   2. Deploy. The next ingestion run picks it up automatically.
+#   3. Monitor pmc_review rows where auto_approved=True to validate the rule.
+#
+# Candidate rules to enable once update patterns are confirmed:
+#
+#   AutoApproveRule(
+#       field="cited_by_count",
+#       label="citation_count_increase",
+#       applies=lambda old, new: isinstance(old, int) and isinstance(new, int) and new >= old,
+#   ),
+#   AutoApproveRule(
+#       field="revision_date",
+#       label="revision_date_update",
+#       applies=lambda old, new: new is not None,
+#   ),
+#   AutoApproveRule(
+#       field="first_index_date",
+#       label="first_index_date_update",
+#       applies=lambda old, new: new is not None,
+#   ),
+#   AutoApproveRule(
+#       field="publication_status",
+#       label="publication_status_progression",
+#       # safe direction: preprint / ahead-of-print moving to published
+#       applies=lambda old, new: old in ("aheadofprint", "ppublish") and new == "ppublish",
+#   ),
+#   AutoApproveRule(
+#       field="is_open_access",
+#       label="open_access_gained",
+#       applies=lambda old, new: old in (None, "N", "false") and new in ("Y", "true"),
+#   ),
+# ---------------------------------------------------------------------------
+AUTO_APPROVE_RULES: List[AutoApproveRule] = []
+
+# Fields compared between staging and production. Excludes PKs, FKs,
+# audit columns, and curation columns (approved_by/approved_at).
+DIFFABLE_FIELDS: List[str] = [
+    "source",
+    "pmc_id",
+    "doi",
+    "title",
+    "pub_year",
+    "abstract_text",
+    "affiliation",
+    "publication_status",
+    "language",
+    "pub_type",
+    "is_open_access",
+    "inepmc",
+    "inpmc",
+    "has_pdf",
+    "has_book",
+    "has_suppl",
+    "cited_by_count",
+    "has_references",
+    "date_of_creation",
+    "first_index_date",
+    "fulltext_receive_date",
+    "revision_date",
+    "epub_date",
+    "first_publication_date",
+]
 
 
 @dataclass
@@ -50,7 +124,7 @@ class AutoClassifyService:
 
     Reads from staging_db (ingestion snapshot).
     Reads from production_db (current curated state).
-    Writes pmc_review rows and audit_log events to staging_db.
+    Writes pmc_review rows to staging_db.
     Updates the ingestion row counts in staging_db at completion.
     """
 
@@ -62,7 +136,7 @@ class AutoClassifyService:
     # Public entry point
     # ------------------------------------------------------------------
 
-    def classify_ingestion_run(self, ingestion_id: int) -> ClassifyResult:
+    def classify_ingestion_run(self, ingestion_id: int, created_by: str = "system") -> ClassifyResult:
         """
         Entry point. Classifies all articles written in this ingestion run.
         Returns a ClassifyResult with per-category counts.
@@ -85,15 +159,76 @@ class AutoClassifyService:
                 continue
 
             if prod_article is None:
+                # ---- NEW -----------------------------------------------
                 result.new_count += 1
+                result.pending_review_count += 1
+                self._write_review(
+                    ingestion_id=ingestion_id,
+                    staged=staged_article,
+                    review_type="new",
+                    diff=None,
+                    auto_approved=False,
+                    auto_approve_reason=None,
+                    review_status="pending",
+                    created_by=created_by,
+                )
                 logger.info(
-                    "COMPARISON_NEW epmc_id=%s ingestion_id=%d",
+                    "CLASSIFICATION_NEW epmc_id=%s ingestion_id=%d",
                     staged_article.epmc_id or staged_article.doi, ingestion_id,
                 )
-                # TODO Step 4: write pmc_review row for NEW
             else:
-                # TODO Step 4: compute diff, route UNCHANGED / CHANGED
-                pass
+                # ---- UNCHANGED or CHANGED ------------------------------
+                diff = self._compute_diff(prod_article, staged_article)
+
+                if not diff:
+                    # UNCHANGED
+                    result.unchanged_count += 1
+                    result.auto_approved_count += 1
+                    self._write_review(
+                        ingestion_id=ingestion_id,
+                        staged=staged_article,
+                        review_type="unchanged",
+                        diff=None,
+                        auto_approved=True,
+                        auto_approve_reason="no_changes_detected",
+                        review_status="approved",
+                        created_by=created_by,
+                    )
+                    logger.debug(
+                        "CLASSIFICATION_UNCHANGED epmc_id=%s ingestion_id=%d",
+                        staged_article.epmc_id or staged_article.doi, ingestion_id,
+                    )
+                else:
+                    # CHANGED — check auto-approve rules
+                    result.changed_count += 1
+                    auto_approved, approve_reason = self._check_auto_approve(diff)
+
+                    if auto_approved:
+                        result.auto_approved_count += 1
+                        review_status = "approved"
+                    else:
+                        result.pending_review_count += 1
+                        review_status = "pending"
+
+                    self._write_review(
+                        ingestion_id=ingestion_id,
+                        staged=staged_article,
+                        review_type="changed",
+                        diff=diff,
+                        auto_approved=auto_approved,
+                        auto_approve_reason=approve_reason,
+                        review_status=review_status,
+                        created_by=created_by,
+                    )
+                    logger.info(
+                        "CLASSIFICATION_CHANGED epmc_id=%s ingestion_id=%d fields=%s auto_approved=%s",
+                        staged_article.epmc_id or staged_article.doi,
+                        ingestion_id,
+                        list(diff.keys()),
+                        auto_approved,
+                    )
+
+        self.staging_db.flush()
 
         # TODO Step 5: audit log events
         # TODO Step 6: write ingestion counts
@@ -104,6 +239,79 @@ class AutoClassifyService:
             result,
         )
         return result
+
+    # ------------------------------------------------------------------
+    # Review writer
+    # ------------------------------------------------------------------
+
+    def _write_review(
+        self,
+        ingestion_id: int,
+        staged: PMCArticle,
+        review_type: str,
+        diff: Optional[Dict[str, Any]],
+        auto_approved: bool,
+        auto_approve_reason: Optional[str],
+        review_status: str,
+        created_by: str,
+    ) -> None:
+        review = PMCReview(
+            ingestion_id=ingestion_id,
+            staging_id=staged.id,
+            epmc_id=staged.epmc_id,
+            doi=staged.doi or None,
+            review_type=review_type,
+            diff=diff,
+            auto_approved=auto_approved,
+            auto_approve_reason=auto_approve_reason,
+            review_status=review_status,
+            created_by=created_by,
+            created_at=datetime.now(timezone.utc),
+        )
+        self.staging_db.add(review)
+
+    # ------------------------------------------------------------------
+    # Diff helpers
+    # ------------------------------------------------------------------
+
+    def _compute_diff(
+        self, prod: PMCArticle, staged: PMCArticle
+    ) -> Dict[str, Any]:
+        """
+        Return a dict of fields that differ between prod and staged.
+        Format: {field: {"old": <prod_value>, "new": <staged_value>}}
+        Empty dict means no differences.
+        """
+        diff: Dict[str, Any] = {}
+        for field in DIFFABLE_FIELDS:
+            old_val = getattr(prod, field, None)
+            new_val = getattr(staged, field, None)
+            if old_val != new_val:
+                diff[field] = {"old": _serialise(old_val), "new": _serialise(new_val)}
+        return diff
+
+    def _check_auto_approve(
+        self, diff: Dict[str, Any]
+    ) -> Tuple[bool, Optional[str]]:
+        """
+        Returns (auto_approved, reason_label).
+        A diff is auto-approved only when EVERY changed field is covered by
+        a rule whose predicate returns True.
+        With an empty rule list (v1) this always returns (False, None).
+        """
+        if not AUTO_APPROVE_RULES:
+            return False, None
+
+        rule_index: Dict[str, AutoApproveRule] = {r.field: r for r in AUTO_APPROVE_RULES}
+        matched_labels: List[str] = []
+
+        for field, change in diff.items():
+            rule = rule_index.get(field)
+            if rule is None or not rule.applies(change["old"], change["new"]):
+                return False, None
+            matched_labels.append(rule.label)
+
+        return True, ",".join(matched_labels)
 
     # ------------------------------------------------------------------
     # Match helpers
@@ -128,7 +336,7 @@ class AutoClassifyService:
         Match strategy:
           1. epmc_id (primary — stable EPMC identifier)
           2. doi     (fallback — used when epmc_id absent)
-          3. Neither present → ("unresolvable", "unresolvable")
+          3. Neither present → (None, "unresolvable")
 
         Returns:
           (production_article, match_key) where match_key is one of:
@@ -150,3 +358,16 @@ class AutoClassifyService:
             return (prod, "doi" if prod else "new")
 
         return (None, "unresolvable")
+
+
+# ------------------------------------------------------------------
+# Utilities
+# ------------------------------------------------------------------
+
+def _serialise(value: Any) -> Any:
+    """Convert non-JSON-serialisable types before storing in JSONB diff."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, (list, dict, str, int, float, bool)) or value is None:
+        return value
+    return str(value)

--- a/src/services/auto_classify.py
+++ b/src/services/auto_classify.py
@@ -3,11 +3,12 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from sqlalchemy import select
+from sqlalchemy import select, update as sa_update
 from sqlalchemy.orm import Session
 
 from src.models.entities.audit_log import AuditLog
 from src.models.entities.enums import AuditEventType
+from src.models.entities.ingestion import Ingestion
 from src.models.entities.known_divergence import KnownDivergence
 from src.models.entities.pmc_article import PMCArticle
 from src.models.entities.pmc_review import PMCReview
@@ -317,7 +318,21 @@ class AutoClassifyService:
         )
         self.staging_db.flush()
 
-        # TODO Step 6: write ingestion counts
+        # Write classification counts back to the ingestion row
+        self.staging_db.execute(
+            sa_update(Ingestion)
+            .where(Ingestion.id == ingestion_id)
+            .values(
+                total_pulled=result.total_pulled,
+                new_count=result.new_count,
+                unchanged_count=result.unchanged_count,
+                changed_count=result.changed_count,
+                auto_approved_count=result.auto_approved_count,
+                pending_review_count=result.pending_review_count,
+                unresolvable_count=result.unresolvable_count,
+            )
+        )
+        self.staging_db.flush()
 
         logger.info(
             "AutoClassifyService: classification complete ingestion_id=%d result=%s",

--- a/src/services/auto_classify.py
+++ b/src/services/auto_classify.py
@@ -1,9 +1,11 @@
 import logging
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
+
+from src.models.entities.pmc_article import PMCArticle
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +58,10 @@ class AutoClassifyService:
         self.staging_db = staging_db
         self.production_db = production_db
 
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
     def classify_ingestion_run(self, ingestion_id: int) -> ClassifyResult:
         """
         Entry point. Classifies all articles written in this ingestion run.
@@ -64,10 +70,32 @@ class AutoClassifyService:
         result = ClassifyResult(ingestion_id=ingestion_id)
         logger.info("AutoClassifyService: starting classification for ingestion_id=%d", ingestion_id)
 
-        # TODO Step 3: load staged articles for this ingestion_id
-        # TODO Step 3: for each article, match against production
-        # TODO Step 4: route to NEW / UNCHANGED / CHANGED branch
-        # TODO Step 5: known divergence check + audit log events
+        staged = self._load_staged_articles(ingestion_id)
+        result.total_pulled = len(staged)
+
+        for staged_article in staged:
+            prod_article, match_key = self._find_in_production(staged_article)
+
+            if match_key == "unresolvable":
+                result.unresolvable_count += 1
+                logger.warning(
+                    "COMPARISON_UNRESOLVABLE ingestion_id=%d article.id=%d",
+                    ingestion_id, staged_article.id,
+                )
+                continue
+
+            if prod_article is None:
+                result.new_count += 1
+                logger.info(
+                    "COMPARISON_NEW epmc_id=%s ingestion_id=%d",
+                    staged_article.epmc_id or staged_article.doi, ingestion_id,
+                )
+                # TODO Step 4: write pmc_review row for NEW
+            else:
+                # TODO Step 4: compute diff, route UNCHANGED / CHANGED
+                pass
+
+        # TODO Step 5: audit log events
         # TODO Step 6: write ingestion counts
 
         logger.info(
@@ -76,3 +104,49 @@ class AutoClassifyService:
             result,
         )
         return result
+
+    # ------------------------------------------------------------------
+    # Match helpers
+    # ------------------------------------------------------------------
+
+    def _load_staged_articles(self, ingestion_id: int) -> List[PMCArticle]:
+        """Return all pmc_articles rows written in this ingestion run."""
+        return (
+            self.staging_db.execute(
+                select(PMCArticle).where(PMCArticle.ingestion_id == ingestion_id)
+            )
+            .scalars()
+            .all()
+        )
+
+    def _find_in_production(
+        self, staged: PMCArticle
+    ) -> Tuple[Optional[PMCArticle], str]:
+        """
+        Look up the staged article in the production DB.
+
+        Match strategy:
+          1. epmc_id (primary — stable EPMC identifier)
+          2. doi     (fallback — used when epmc_id absent)
+          3. Neither present → ("unresolvable", "unresolvable")
+
+        Returns:
+          (production_article, match_key) where match_key is one of:
+            "epmc_id"       — matched on epmc_id
+            "doi"           — matched on doi
+            "new"           — no match found (record is new to production)
+            "unresolvable"  — neither epmc_id nor doi present on staged article
+        """
+        if staged.epmc_id:
+            prod = self.production_db.execute(
+                select(PMCArticle).where(PMCArticle.epmc_id == staged.epmc_id)
+            ).scalar_one_or_none()
+            return (prod, "epmc_id" if prod else "new")
+
+        if staged.doi:
+            prod = self.production_db.execute(
+                select(PMCArticle).where(PMCArticle.doi == staged.doi)
+            ).scalar_one_or_none()
+            return (prod, "doi" if prod else "new")
+
+        return (None, "unresolvable")

--- a/src/services/epmc.py
+++ b/src/services/epmc.py
@@ -32,17 +32,28 @@ class EPMCService:
             return []
         return value if isinstance(value, list) else [value]
 
-    def _detect_run_type(self) -> tuple:
+    def fetch_delta_epmc_ids(
+        self, keyword: str, from_date: str, to_date: Optional[str] = None
+    ) -> set:
         """
-        Auto-detect whether the next ingestion should be a full or delta pull.
+        Phase 1 — fetch delta article IDs from EPMC (in-memory only, no DB writes).
 
-        Returns (run_type, from_date) where from_date is a YYYY-MM-DD string
-        for delta runs, or None for full runs.
+        Returns the set of epmc_ids that have been updated in the given date window.
+        These IDs are passed to AutoClassifyService so only delta-flagged articles
+        are diffed against production; all other production articles are skipped.
         """
-        last_date = self.epmc_repo.get_last_ingestion_date()
-        if last_date is None:
-            return "full", None
-        return "delta", last_date.strftime("%Y-%m-%d")
+        effective_to = to_date or datetime.utcnow().strftime("%Y-%m-%d")
+        logger.info(
+            "Phase 1 — delta pull (in-memory): keyword=%s from_date=%s to_date=%s",
+            keyword, from_date, effective_to,
+        )
+        json_response = self.epmc_client.get_delta_articles(keyword, from_date, effective_to)
+        results = json_response.get("resultList", {}).get("result", []) or []
+        epmc_ids = {r.get("id") for r in results if r.get("id")}
+        logger.info(
+            "Phase 1 — delta pull complete: %d articles updated since %s", len(epmc_ids), from_date
+        )
+        return epmc_ids
 
     @staticmethod
     def _positive_int(value):
@@ -135,6 +146,7 @@ class EPMCService:
                 action_by=created_by,
                 action_at=datetime.utcnow(),
             ))
+            self.epmc_repo.commit_to_db()
         except Exception:
             logger.exception("Failed to write INGESTION_FAILED audit log")
 
@@ -142,32 +154,12 @@ class EPMCService:
         self,
         keyword: str,
         created_by: str,
-        from_date: Optional[str] = None,
-        to_date: Optional[str] = None,
+        run_type: str = "full",
     ) -> dict[str, int]:
-        # Explicit date range → always a delta pull, no auto-detect needed.
-        # No dates → auto-detect: delta if prior ingestion exists, full otherwise.
-        if from_date:
-            run_type = "delta"
-            effective_to = to_date or datetime.utcnow().strftime("%Y-%m-%d")
-            logger.info(
-                "Delta pull (explicit): keyword=%s from_date=%s to_date=%s",
-                keyword, from_date, effective_to,
-            )
-            json_response = self.epmc_client.get_delta_articles(keyword, from_date, effective_to)
-        else:
-            run_type, detected_from = self._detect_run_type()
-            effective_to = datetime.utcnow().strftime("%Y-%m-%d")
-            if run_type == "delta":
-                logger.info(
-                    "Delta pull (auto): keyword=%s from_date=%s to_date=%s",
-                    keyword, detected_from, effective_to,
-                )
-                json_response = self.epmc_client.get_delta_articles(keyword, detected_from, effective_to)
-            else:
-                logger.info("Full pull: keyword=%s", keyword)
-                json_response = self.epmc_client.get_articles(keyword)
-
+        # Phase 2 — always a full pull. Delta classification is handled separately
+        # in Phase 1 (fetch_delta_epmc_ids) before this method is called.
+        logger.info("Phase 2 — full pull: keyword=%s run_type=%s", keyword, run_type)
+        json_response = self.epmc_client.get_articles(keyword)
         results = json_response.get("resultList", {}).get("result", []) or []
 
         ingestion_version = self._next_ingestion_version()
@@ -201,6 +193,9 @@ class EPMCService:
                 article_id = self.epmc_repo.insert_or_update(article_entity, PMCArticle, is_update)
                 counts["articles"] += 1
                 self.ingested_articles[article.get("id")] = article_id
+
+                if counts["articles"] % 10 == 0:
+                    logger.info("Progress: %d/%d articles processed...", counts["articles"], len(results))
 
                 for cite in (citation_data.get("citationList") or {}).get("citation") or []:
                     existing_citation = False
@@ -275,9 +270,7 @@ class EPMCService:
             
             ingestion_model = self.epmc_client.update_ingestion(self.ingestion_id, counts["articles"])
             self.epmc_repo.update_ingestion_count(ingestion_model, Ingestion)
-            self.epmc_repo.commit_to_db()
         except Exception:
-            self.epmc_repo.rollback()
             raise
         logger.info("Article ingestion complete: %s", counts)
         return counts

--- a/src/services/epmc.py
+++ b/src/services/epmc.py
@@ -78,7 +78,12 @@ class EPMCService:
         results = json_response.get("resultList", {}).get("result", []) or []
 
         ingestion_version = self._next_ingestion_version()
-        ingestion_model = self.epmc_client.create_ingestion(ingestion_version, created_by=created_by)
+        ingestion_model = self.epmc_client.create_ingestion(
+            ingestion_version,
+            keyword=keyword,
+            run_type="full",
+            created_by=created_by,
+        )
         ingestion_id = self.epmc_repo.insert_or_update(ingestion_model, Ingestion, False)
         self.ingestion_id = ingestion_id
 
@@ -175,8 +180,8 @@ class EPMCService:
                             counts["affiliations"] += 1
                             fallback_affiliation_order += 1
             
-            #ingestion_model = self.epmc_client.update_ingestion(self.ingestion_id, counts["articles"])    
-            #self.epmc_repo.update_ingestion_count(ingestion_model, Ingestion) 
+            ingestion_model = self.epmc_client.update_ingestion(self.ingestion_id, counts["articles"])
+            self.epmc_repo.update_ingestion_count(ingestion_model, Ingestion)
             self.epmc_repo.commit_to_db()
         except Exception:
             self.epmc_repo.rollback()
@@ -224,10 +229,14 @@ class EPMCService:
             if not article_map:
                 raise ValueError("Ingestion ID is not set and use_db_articles is False. Please run insert_articles_by_keyword first or set use_db_articles=True.")
 
-        # Create ingestion if needed (for new reference records)
+        # Create ingestion if needed (for standalone reference ingestion with no prior article run)
         if self.ingestion_id is None:
             ingestion_version = self._next_ingestion_version()
-            ingestion_model = self.epmc_client.create_ingestion(ingestion_version, created_by)
+            ingestion_model = self.epmc_client.create_ingestion(
+                ingestion_version,
+                run_type="full",
+                created_by=created_by,
+            )
             self.ingestion_id = self.epmc_repo.insert_or_update(ingestion_model, Ingestion, False)
 
         try:

--- a/src/services/epmc.py
+++ b/src/services/epmc.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Counter, List
+from datetime import datetime
+from typing import Any, Counter, List, Optional
 from src.clients.epmc import EPMCClient
 from src.models.citation import CitationOverYears, TotalCitations
 from src.models.entities.pmc_article import PMCArticle
@@ -8,6 +9,8 @@ from src.models.entities.extras import Grant, FullText, Keyword
 from src.models.entities.citations import Citation, Reference
 from src.models.entities.record import Record, RecordType, Source, Status, ProductType
 from src.models.entities.ingestion import Ingestion
+from src.models.entities.audit_log import AuditLog
+from src.models.entities.enums import AuditEventType
 from src.repositories.epmc import EPMCRepo
 
 logger = logging.getLogger(__name__)
@@ -28,6 +31,18 @@ class EPMCService:
         if value is None:
             return []
         return value if isinstance(value, list) else [value]
+
+    def _detect_run_type(self) -> tuple:
+        """
+        Auto-detect whether the next ingestion should be a full or delta pull.
+
+        Returns (run_type, from_date) where from_date is a YYYY-MM-DD string
+        for delta runs, or None for full runs.
+        """
+        last_date = self.epmc_repo.get_last_ingestion_date()
+        if last_date is None:
+            return "full", None
+        return "delta", last_date.strftime("%Y-%m-%d")
 
     @staticmethod
     def _positive_int(value):
@@ -71,17 +86,95 @@ class EPMCService:
         except Exception:
             logger.warning("Could not fetch highest ingestion version; defaulting to 1")
             return 1
-        
-    def insert_articles_by_keyword(self, keyword: str, created_by: str) -> dict[str, int]:
 
-        json_response = self.epmc_client.get_articles(keyword)
+    # ------------------------------------------------------------------
+    # Ingestion lifecycle audit events
+    # ------------------------------------------------------------------
+
+    def record_ingestion_started(self, keyword: str, run_type: str = "full", created_by: str = "system") -> None:
+        self.epmc_repo.insert_audit_log(AuditLog(
+            event_type=AuditEventType.INGESTION_STARTED,
+            entity_type="ingestion",
+            new_value={"keyword": keyword, "run_type": run_type},
+            action_by=created_by,
+            action_at=datetime.utcnow(),
+        ))
+
+    def record_ingestion_completed(
+        self, ingestion_id: int, keyword: str, classify_result: Any, created_by: str = "system"
+    ) -> None:
+        self.epmc_repo.insert_audit_log(AuditLog(
+            event_type=AuditEventType.INGESTION_COMPLETED,
+            entity_type="ingestion",
+            entity_id=str(ingestion_id),
+            ingestion_id=ingestion_id,
+            new_value={
+                "keyword": keyword,
+                "total_pulled": classify_result.total_pulled,
+                "new_count": classify_result.new_count,
+                "unchanged_count": classify_result.unchanged_count,
+                "changed_count": classify_result.changed_count,
+                "auto_approved_count": classify_result.auto_approved_count,
+                "pending_review_count": classify_result.pending_review_count,
+                "unresolvable_count": classify_result.unresolvable_count,
+            },
+            action_by=created_by,
+            action_at=datetime.utcnow(),
+        ))
+
+    def record_ingestion_failed(
+        self, ingestion_id: Optional[int], keyword: str, error: str, created_by: str = "system"
+    ) -> None:
+        try:
+            self.epmc_repo.insert_audit_log(AuditLog(
+                event_type=AuditEventType.INGESTION_FAILED,
+                entity_type="ingestion",
+                entity_id=str(ingestion_id) if ingestion_id else None,
+                ingestion_id=ingestion_id,
+                new_value={"error": error, "keyword": keyword},
+                action_by=created_by,
+                action_at=datetime.utcnow(),
+            ))
+        except Exception:
+            logger.exception("Failed to write INGESTION_FAILED audit log")
+
+    def insert_articles_by_keyword(
+        self,
+        keyword: str,
+        created_by: str,
+        from_date: Optional[str] = None,
+        to_date: Optional[str] = None,
+    ) -> dict[str, int]:
+        # Explicit date range → always a delta pull, no auto-detect needed.
+        # No dates → auto-detect: delta if prior ingestion exists, full otherwise.
+        if from_date:
+            run_type = "delta"
+            effective_to = to_date or datetime.utcnow().strftime("%Y-%m-%d")
+            logger.info(
+                "Delta pull (explicit): keyword=%s from_date=%s to_date=%s",
+                keyword, from_date, effective_to,
+            )
+            json_response = self.epmc_client.get_delta_articles(keyword, from_date, effective_to)
+        else:
+            run_type, detected_from = self._detect_run_type()
+            effective_to = datetime.utcnow().strftime("%Y-%m-%d")
+            if run_type == "delta":
+                logger.info(
+                    "Delta pull (auto): keyword=%s from_date=%s to_date=%s",
+                    keyword, detected_from, effective_to,
+                )
+                json_response = self.epmc_client.get_delta_articles(keyword, detected_from, effective_to)
+            else:
+                logger.info("Full pull: keyword=%s", keyword)
+                json_response = self.epmc_client.get_articles(keyword)
+
         results = json_response.get("resultList", {}).get("result", []) or []
 
         ingestion_version = self._next_ingestion_version()
         ingestion_model = self.epmc_client.create_ingestion(
             ingestion_version,
             keyword=keyword,
-            run_type="full",
+            run_type=run_type,
             created_by=created_by,
         )
         ingestion_id = self.epmc_repo.insert_or_update(ingestion_model, Ingestion, False)
@@ -226,8 +319,11 @@ class EPMCService:
         else:
             # Use articles from recent ingestion (self.ingested_articles key=pm_id, value=internal_id)
             article_map = self.ingested_articles
-            if not article_map:
+            if article_map is None:
                 raise ValueError("Ingestion ID is not set and use_db_articles is False. Please run insert_articles_by_keyword first or set use_db_articles=True.")
+            if not article_map:
+                logger.info("insert_references: no articles in this ingestion run, skipping")
+                return counts
 
         # Create ingestion if needed (for standalone reference ingestion with no prior article run)
         if self.ingestion_id is None:


### PR DESCRIPTION
Implements a classification pipeline that determines whether articles pulled from EuropePMC are new, changed, or unchanged relative to the production database.

Ingestion is now distributed in two phases:
  - **Phase 1 — Delta pull (in-memory, no DB writes)**
    - Fetches article IDs updated since the last successful ingestion using EPMC's UPDATE_DATE filter
    - Builds an in-memory delta_epmc_ids set — no staging DB writes at this stage
    - run_type recorded as full+delta when a delta window exists, full on first-ever run
  **- Phase 2 — Full pull (always writes to staging)**
    - Pulls all articles from EPMC and writes to staging DB regardless of delta 

**Classification logic**
Each staged article is classified against production (the approved baseline):
**NEW** — not in production → creates a pmc_review row (status: pending)
**CHANGED** — in production AND in delta → diffs fields, creates/updates a pmc_review row
**UNCHANGED** — in production AND in delta, no diff → auto-approved, audit log only (no review row)
**SKIPPED** — in production but NOT in delta window → no review needed, just counted


